### PR TITLE
Add assembly sbom feature for cyclonedx

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ for input and output formats
 We currently support two algorithm 
 - Hierarchical: This merge algo tries to maintain, the order of the dependent components to its primary component. For spdx this is done via relationships and for cyclonedx via nested components & dependencies. 
 - Flat: As the name states, are just consolidated lists of components, dependencies, etc. 
+- Assembly: Merge is very similar to Hierarchical, except that it does not create dependency relationships among the merged sboms. 
 
 For `spdx hierarchical merge`, all packages, dependencies, externalrefs, files are consolidates into a individual lists, no duplicates are removed. The hierarchy is maintained via dependencies. A new primary package is created, which the generated SBOM describes. This primary package also adds contains
 relationship between itself and the primary components of the individual SBOMs. 

--- a/cmd/assemble.go
+++ b/cmd/assemble.go
@@ -72,10 +72,13 @@ func init() {
 	assembleCmd.MarkFlagsRequiredTogether("name", "version", "type")
 
 	assembleCmd.Flags().BoolP("flatMerge", "f", false, "flat merge")
-	assembleCmd.Flags().BoolP("hierMerge", "m", true, "hierarchical merge")
+	assembleCmd.Flags().BoolP("hierMerge", "m", false, "hierarchical merge")
+	assembleCmd.Flags().BoolP("assemblyMerge", "a", false, "assembly merge")
+	assembleCmd.MarkFlagsMutuallyExclusive("flatMerge", "hierMerge", "assemblyMerge")
 
 	assembleCmd.Flags().BoolP("xml", "x", false, "output in xml format")
 	assembleCmd.Flags().BoolP("json", "j", true, "output in json format")
+	assembleCmd.MarkFlagsMutuallyExclusive("xml", "json")
 
 	assembleCmd.PersistentFlags().BoolP("debug", "d", false, "debug output")
 }
@@ -125,13 +128,11 @@ func extractArgs(cmd *cobra.Command, args []string) (*assemble.Params, error) {
 
 	flatMerge, _ := cmd.Flags().GetBool("flatMerge")
 	hierMerge, _ := cmd.Flags().GetBool("hierMerge")
-
-	if flatMerge {
-		hierMerge = false
-	}
+	assemblyMerge, _ := cmd.Flags().GetBool("assemblyMerge")
 
 	aParams.FlatMerge = flatMerge
 	aParams.HierMerge = hierMerge
+	aParams.AssemblyMerge = assemblyMerge
 
 	xml, _ := cmd.Flags().GetBool("xml")
 	json, _ := cmd.Flags().GetBool("json")

--- a/pkg/assemble/cdx/interface.go
+++ b/pkg/assemble/cdx/interface.go
@@ -109,6 +109,7 @@ type assemble struct {
 	IncludeDuplicateComponents bool
 	FlatMerge                  bool
 	HierarchicalMerge          bool
+	AssemblyMerge              bool
 }
 
 type MergeSettings struct {
@@ -129,7 +130,9 @@ func Merge(ms *MergeSettings) error {
 		return merger.flatMerge()
 	} else if ms.Assemble.HierarchicalMerge {
 		return merger.hierarchicalMerge()
+	} else if ms.Assemble.AssemblyMerge {
+		return merger.assemblyMerge()
 	}
 
-	return nil
+	return merger.hierarchicalMerge()
 }

--- a/pkg/assemble/combiner.go
+++ b/pkg/assemble/combiner.go
@@ -88,6 +88,7 @@ func toCDXMergerSettings(c *config) *cdx.MergeSettings {
 
 	ms.Assemble.FlatMerge = c.Assemble.FlatMerge
 	ms.Assemble.HierarchicalMerge = c.Assemble.HierarchicalMerge
+	ms.Assemble.AssemblyMerge = c.Assemble.AssemblyMerge
 	ms.Assemble.IncludeComponents = c.Assemble.IncludeComponents
 	ms.Assemble.IncludeDuplicateComponents = c.Assemble.includeDuplicateComponents
 	ms.Assemble.IncludeDependencyGraph = c.Assemble.IncludeDependencyGraph

--- a/pkg/assemble/config.go
+++ b/pkg/assemble/config.go
@@ -19,7 +19,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -85,6 +84,7 @@ type assemble struct {
 	includeDuplicateComponents bool
 	FlatMerge                  bool `yaml:"flat_merge"`
 	HierarchicalMerge          bool `yaml:"hierarchical_merge"`
+	AssemblyMerge              bool `yaml:"assembly_merge"`
 }
 
 type config struct {
@@ -125,6 +125,7 @@ var defaultConfig = config{
 	Assemble: assemble{
 		FlatMerge:                  false,
 		HierarchicalMerge:          true,
+		AssemblyMerge:              false,
 		IncludeComponents:          true,
 		IncludeDependencyGraph:     true,
 		includeDuplicateComponents: true,
@@ -158,7 +159,7 @@ func newConfig() *config {
 func (c *config) readAndMerge(p *Params) error {
 	if p.ConfigPath != "" {
 
-		yF, err := ioutil.ReadFile(p.ConfigPath)
+		yF, err := os.ReadFile(p.ConfigPath)
 		if err != nil {
 			return err
 		}
@@ -171,6 +172,7 @@ func (c *config) readAndMerge(p *Params) error {
 
 		c.Assemble.FlatMerge = p.FlatMerge
 		c.Assemble.HierarchicalMerge = p.HierMerge
+		c.Assemble.AssemblyMerge = p.AssemblyMerge
 	}
 
 	c.input.files = p.Input
@@ -274,14 +276,6 @@ func (c *config) validate() error {
 
 	if c.input.files == nil || len(c.input.files) == 0 {
 		return fmt.Errorf("input files are not set")
-	}
-
-	if !c.Assemble.FlatMerge && !c.Assemble.HierarchicalMerge {
-		return fmt.Errorf("flat merge or hierarchical merge must be set")
-	}
-
-	if c.Assemble.FlatMerge && c.Assemble.HierarchicalMerge {
-		return fmt.Errorf("flat merge or hierarchical merger can be set, not both")
 	}
 
 	err := c.validateInputContent()

--- a/pkg/assemble/interface.go
+++ b/pkg/assemble/interface.go
@@ -28,8 +28,9 @@ type Params struct {
 	Version string
 	Type    string
 
-	FlatMerge bool
-	HierMerge bool
+	FlatMerge     bool
+	HierMerge     bool
+	AssemblyMerge bool
 
 	Xml  bool
 	Json bool

--- a/pkg/assemble/spdx/interface.go
+++ b/pkg/assemble/spdx/interface.go
@@ -85,6 +85,7 @@ type assemble struct {
 	IncludeDuplicateComponents bool
 	FlatMerge                  bool
 	HierarchicalMerge          bool
+	AssemblyMerge              bool
 }
 
 type MergeSettings struct {
@@ -104,6 +105,10 @@ func Merge(ms *MergeSettings) error {
 	if ms.Assemble.FlatMerge {
 		return merger.flatMerge()
 	} else if ms.Assemble.HierarchicalMerge {
+		return merger.hierarchicalMerge()
+	} else if ms.Assemble.AssemblyMerge {
+		return merger.assemblyMerge()
+	} else {
 		return merger.hierarchicalMerge()
 	}
 

--- a/pkg/assemble/spdx/merge.go
+++ b/pkg/assemble/spdx/merge.go
@@ -349,7 +349,11 @@ func (m *merge) hierarchicalMerge() error {
 }
 
 func (m *merge) flatMerge() error {
-	return fmt.Errorf("spdx flat merge not implemented")
+	return fmt.Errorf("not implemented")
+}
+
+func (m *merge) assemblyMerge() error {
+	return fmt.Errorf("not implemented")
 }
 
 func (m *merge) writeSBOM() error {


### PR DESCRIPTION
This adds a new merge type for sbomasm, called "Assembly merge".  This new merge is very similar to an hierarchical merge except no dependency relationships are created. 