### PR TITLE
Feature/uniq custom licenses

### DIFF
--- a/pkg/assemble/spdx/merge.go
+++ b/pkg/assemble/spdx/merge.go
@@ -192,7 +192,7 @@ func (m *merge) hierarchicalMerge() error {
 	})
 
 	for _, doc := range m.in {
-		log.Debugf("processing sbom %s with packages:%d, files:%d, deps:%d, Snips:%d OtherLics:%d, Annotations:%d, externaldocrefs:%d",
+		log.Debugf("processing sbom %s with packages:%d, docFiles:%d, deps:%d, Snips:%d OtherLics:%d, Annotations:%d, externaldocrefs:%d",
 			fmt.Sprintf("%s-%s", doc.SPDXIdentifier, doc.DocumentName),
 			len(doc.Packages), len(doc.Files), len(doc.Relationships),
 			len(doc.Snippets), len(doc.OtherLicenses), len(doc.Annotations),
@@ -209,6 +209,7 @@ func (m *merge) hierarchicalMerge() error {
 		oldDocPrimaryPackageIdent := common.ElementID("")
 
 		for _, pkg := range doc.Packages {
+			log.Debugf("\tpackage %s : %s with pkgFiles:%d", pkg.PackageName, pkg.PackageVersion, len(pkg.Files))
 			isDescPkg := m.isDescribedPackage(pkg, descRels)
 
 			cPkg, err := cloneComp(pkg)

--- a/pkg/assemble/spdx/merge.go
+++ b/pkg/assemble/spdx/merge.go
@@ -55,7 +55,6 @@ func (m *merge) loadBoms() {
 }
 
 func (m *merge) initOutBom() {
-	//log := logger.FromContext(*m.settings.Ctx)
 	m.out.SPDXVersion = spdx.Version
 	m.out.DataLicense = spdx.DataLicense
 	m.out.SPDXIdentifier = common.ElementID("DOCUMENT")
@@ -64,18 +63,8 @@ func (m *merge) initOutBom() {
 	m.out.CreationInfo = &v2_3.CreationInfo{}
 	m.out.CreationInfo.Created = utcNowTime()
 
-	for _, author := range m.settings.App.Authors {
-		c := common.Creator{}
-		c.CreatorType = "Organization"
-
-		if author.Name != "" || author.Email != "" {
-			c.Creator = fmt.Sprintf("%s (%s)", author.Name, author.Email)
-		}
-		m.out.CreationInfo.Creators = append(m.out.CreationInfo.Creators, c)
-	}
-
 	//Add all creators from the input sboms
-	creators := getAllCreators(m.in)
+	creators := getAllCreators(m.in, m.settings.App.Authors)
 	m.out.CreationInfo.Creators = append(m.out.CreationInfo.Creators, creators...)
 
 	version := getLicenseListVersion(m.in)
@@ -301,14 +290,10 @@ func (m *merge) hierarchicalMerge() error {
 
 	files = append(files, docFiles...)
 
-	otherLics := lo.FlatMap(m.in, func(doc *spdx.Document, _ int) []*spdx.OtherLicense {
-		return doc.OtherLicenses
-	})
-
 	m.out.Packages = pkgs
 	m.out.Files = files
 	m.out.Relationships = deps
-	m.out.OtherLicenses = otherLics
+	m.out.OtherLicenses = getOtherLicenses(m.in)
 
 	return m.writeSBOM()
 }

--- a/pkg/assemble/spdx/utils.go
+++ b/pkg/assemble/spdx/utils.go
@@ -81,9 +81,7 @@ func loadBom(ctx context.Context, path string) (*v2_3.Document, error) {
 }
 
 func utcNowTime() string {
-	location, _ := time.LoadLocation("UTC")
-	locationTime := time.Now().In(location)
-	return locationTime.Format("2006-01-02T15:04:05Z")
+	return time.Now().UTC().Format(time.RFC3339)
 }
 
 func cloneComp(c *spdx.Package) (*spdx.Package, error) {
@@ -194,6 +192,10 @@ func getLicenseListVersion(docs []*v2_3.Document) string {
 		return ""
 	}))
 
+	if len(versions) == 0 {
+		return ""
+	}
+
 	sort.Slice(versions, func(i, j int) bool {
 		return compareVersions(versions[i], versions[j])
 	})
@@ -224,6 +226,10 @@ func getOtherLicenses(docs []*v2_3.Document) []*v2_3.OtherLicense {
 	customLicenses := lo.FlatMap(docs, func(doc *spdx.Document, _ int) []*spdx.OtherLicense {
 		return doc.OtherLicenses
 	})
+
+	if len(customLicenses) == 0 {
+		return nil
+	}
 
 	return lo.UniqBy(customLicenses, func(license *spdx.OtherLicense) string {
 		// A license would be unique if the identifier is the same & content


### PR DESCRIPTION
Based on user feedback added the following for SPDX merge

- If custom licenses are present, then we uniq them by ID & Content, and add only the uniq list. 
- In case license list is absent, we omit outputting it in the final sbom, its an optional field. 
- UTC timestamp was computed incorrectly, fixed. 
