### PR TITLE
Clears package verification code, if value is empty and reset files a…

### DIFF
--- a/pkg/assemble/spdx/merge.go
+++ b/pkg/assemble/spdx/merge.go
@@ -234,6 +234,11 @@ func (m *merge) hierarchicalMerge() error {
 				cPkg.PackageVerificationCode = nil
 			}
 
+			if cPkg.PackageVerificationCode != nil && cPkg.PackageVerificationCode.Value == "" {
+				cPkg.PackageVerificationCode = nil
+				cPkg.FilesAnalyzed = false
+			}
+
 			for _, f := range cPkg.Files {
 				if f.FileSPDXIdentifier == "" {
 					continue


### PR DESCRIPTION
The internal spdx library, returns an initialized packageVerificationCode object, even though its not present. Added code to mitigate this. 