### PR TITLE
sbom generation using sbom-tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Get Tag
         id: get_tag
         run: echo "LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 'v0.0.1')" >> $GITHUB_ENV
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x" # Specify the Python version needed
       
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@v4
@@ -52,24 +47,11 @@ jobs:
 
       - run: go version
       - run: goreleaser -v 
+      
       - name: Releaser
         run: make release 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout Python SBOM tool
-        run: |
-          git clone https://github.com/interlynk-io/pylynk.git ${{ env.PYLYNK_TEMP_DIR }}
-          cd ${{ env.PYLYNK_TEMP_DIR }}
-          git fetch --tags
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          git checkout $latest_tag
-          echo "Checked out pylynk at tag: $latest_tag"
-
-      - name: Install Python dependencies
-        run: |
-          cd ${{ env.PYLYNK_TEMP_DIR }}
-          pip install -r requirements.txt
 
       - name: Generate SBOM
         shell: bash
@@ -87,7 +69,7 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ${{ env.SBOM_FILE_PATH }}
-          asset_name: sbomasm.sbom.spdx.json
+          asset_name: sbomasm-${{ env.LATEST_TAG }}.sbom.spdx.json
           asset_content_type: application/json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,19 @@ on:
       - 'v*'
   workflow_dispatch:
 
+env:
+  TOOL_NAME: ${{ github.repository }}
+  LATEST_TAG: v0.0.1
+  SUPPLIER_NAME: Interlynk
+  SUPPLIER_URL: https://interlynk.io
+  PYLYNK_TEMP_DIR: $RUNNER_TEMP/pylynk
+  SBOM_TEMP_DIR: $RUNNER_TEMP/sbom
+  SBOM_ENV: development
+  SBOM_FILE_PATH: $RUNNER_TEMP/sbom/_manifest/spdx_2.2/manifest.spdx.json
+  MS_SBOM_TOOL_URL: https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
+  MS_SBOM_TOOL_EXCLUDE_DIRS: "**/samples/**"
+
+  
 jobs:
   releaser:
     runs-on: ubuntu-latest
@@ -22,17 +35,59 @@ jobs:
           go-version: '>=1.20'
           check-latest: true
           cache: true
-      - name: Download syft binary
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
-      - name: Run syft
-        run: syft version
+      
+      - name: Get Tag
+        id: get_tag
+        run: echo "LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 'v0.0.1')" >> $GITHUB_ENV
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x" # Specify the Python version needed
+      
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          install-only: true 
+          install-only: true
+
       - run: go version
       - run: goreleaser -v 
       - name: Releaser
         run: make release 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout Python SBOM tool
+        run: |
+          git clone https://github.com/interlynk-io/pylynk.git ${{ env.PYLYNK_TEMP_DIR }}
+          cd ${{ env.PYLYNK_TEMP_DIR }}
+          git fetch --tags
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $latest_tag
+          echo "Checked out pylynk at tag: $latest_tag"
+
+      - name: Install Python dependencies
+        run: |
+          cd ${{ env.PYLYNK_TEMP_DIR }}
+          pip install -r requirements.txt
+
+      - name: Generate SBOM
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}
+          mkdir -p ${{ env.SBOM_TEMP_DIR}}
+          curl -Lo $RUNNER_TEMP/sbom-tool ${{ env.MS_SBOM_TOOL_URL }}
+          chmod +x $RUNNER_TEMP/sbom-tool
+          SANITIZED_REF=$(echo "${{ github.ref_name}}" | sed -e 's/[^a-zA-Z0-9.-]/-/g' -e 's/^[^a-zA-Z0-9]*//g')
+          VERSION= ${{ env.LATEST_TAG }}-$SANITIZED_REF          
+          $RUNNER_TEMP/sbom-tool generate -b ${{ env.SBOM_TEMP_DIR }} -bc . -pn ${{ env.TOOL_NAME }} -pv $VERSION -ps ${{ env.SUPPLIER_NAME}} -nsb ${{ env.SUPPLIER_URL }} -cd "--DirectoryExclusionList ${{ env.MS_SBOM_TOOL_EXCLUDE_DIRS }}"
+      
+      - name: Upload SBOM as Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.SBOM_FILE_PATH }}
+          asset_name: sbomasm.sbom.spdx.json
+          asset_content_type: application/json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 project_name: sbomasm
 
+version: 2
+
 env:
   - GO111MODULE=on
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,8 +63,3 @@ release:
   prerelease: allow 
   draft: true 
 
-sboms:
-  -
-    artifacts: binary
-    documents:
-      - "${artifact}.spdx.sbom"  


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomasm/issues/93

The SBOM is currently generated from the binary using the sbom section of GoReleaser. [goreleaser](https://goreleaser.com/blog/supply-chain-security/) utilizes the syft tool for SBOM creation, but due to issues with syft, we are transitioning to [sbom-tool](https://github.com/microsoft/sbom-tool) for SBOM generation in our CI/CD pipeline.