### PR TITLE
Fix SPDX tool format

### DIFF
--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -364,9 +364,11 @@ func (d *spdxEditDoc) tools() error {
 	tools := []spdx.Creator{}
 
 	for _, tool := range d.c.tools {
+		parts := []string{tool.name, tool.value}
+
 		tools = append(tools, spdx.Creator{
 			CreatorType: "Tool",
-			Creator:     fmt.Sprintf("%s (%s)", tool.name, tool.value),
+			Creator:     strings.Join(lo.Compact(parts), "-"),
 		})
 	}
 


### PR DESCRIPTION
The current spdx edit has a bug with tool formatting.

Currently after SPDX edit:
```
   Tool: trivy (0.56.1)
   Tool: parlay (0.5.1)
   Tool: bomctl (v0.4.1)
```

After this change
```
 Tool: trivy-0.56.1
 Tool: parlay-0.5.1
 Tool: bomctl-v0.4.1
```