### PR TITLE
Fix/unique tools

### DIFF
--- a/pkg/edit/cdx.go
+++ b/pkg/edit/cdx.go
@@ -178,6 +178,93 @@ func cdxFindComponent(b *cydx.BOM, c *configParams) *cydx.Component {
 	return nil
 }
 
+func cdxUniqTools(a *cydx.ToolsChoice, b *cydx.ToolsChoice) *cydx.ToolsChoice {
+	choices := cydx.ToolsChoice{}
+
+	if a == nil && b == nil {
+		return &choices
+	}
+
+	if a == nil && b != nil {
+		return b
+	}
+
+	if a != nil && b == nil {
+		return a
+	}
+
+	if a.Tools != nil && b.Tools != nil {
+		choices.Tools = new([]cydx.Tool)
+		uniqTools := make(map[string]string)
+
+		for _, tool := range *a.Tools {
+			key := fmt.Sprintf("%s-%s", strings.ToLower(tool.Name), strings.ToLower(tool.Version))
+
+			if _, ok := uniqTools[key]; !ok {
+				*choices.Tools = append(*choices.Tools, tool)
+				uniqTools[key] = key
+			}
+		}
+
+		for _, tool := range *b.Tools {
+			key := fmt.Sprintf("%s-%s", strings.ToLower(tool.Name), strings.ToLower(tool.Version))
+
+			if _, ok := uniqTools[key]; !ok {
+				*choices.Tools = append(*choices.Tools, tool)
+				uniqTools[key] = key
+			}
+		}
+	}
+
+	if a.Components != nil && b.Components != nil {
+		choices.Components = new([]cydx.Component)
+		uniqTools := make(map[string]string)
+
+		for _, tool := range *a.Components {
+			key := fmt.Sprintf("%s-%s", strings.ToLower(tool.Name), strings.ToLower(tool.Version))
+
+			if _, ok := uniqTools[key]; !ok {
+				*choices.Components = append(*choices.Components, tool)
+				uniqTools[key] = key
+			}
+		}
+
+		for _, tool := range *b.Components {
+			key := fmt.Sprintf("%s-%s", strings.ToLower(tool.Name), strings.ToLower(tool.Version))
+
+			if _, ok := uniqTools[key]; !ok {
+				*choices.Components = append(*choices.Components, tool)
+				uniqTools[key] = key
+			}
+		}
+	}
+
+	if a.Services != nil && b.Services != nil {
+		choices.Services = new([]cydx.Service)
+		uniqTools := make(map[string]string)
+
+		for _, tool := range *a.Services {
+			key := fmt.Sprintf("%s-%s", strings.ToLower(tool.Name), strings.ToLower(tool.Version))
+
+			if _, ok := uniqTools[key]; !ok {
+				*choices.Services = append(*choices.Services, tool)
+				uniqTools[key] = key
+			}
+		}
+
+		for _, tool := range *b.Services {
+			key := fmt.Sprintf("%s-%s", strings.ToLower(tool.Name), strings.ToLower(tool.Version))
+
+			if _, ok := uniqTools[key]; !ok {
+				*choices.Services = append(*choices.Services, tool)
+				uniqTools[key] = key
+			}
+		}
+	}
+
+	return &choices
+}
+
 func cdxConstructTools(b *cydx.BOM, c *configParams) *cydx.ToolsChoice {
 	choice := cydx.ToolsChoice{}
 
@@ -226,7 +313,7 @@ func cdxConstructHashes(_ *cydx.BOM, c *configParams) *[]cydx.Hash {
 	return &hashes
 }
 
-func cdxConstructLicenses(b *cydx.BOM, c *configParams) cydx.Licenses {
+func cdxConstructLicenses(_ *cydx.BOM, c *configParams) cydx.Licenses {
 	licenses := cydx.Licenses{}
 
 	for _, license := range c.licenses {

--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -285,18 +285,7 @@ func (d *cdxEditDoc) tools() error {
 		}
 	} else if d.c.onAppend() {
 		if d.bom.Metadata.Tools != nil {
-			if d.bom.SpecVersion > cydx.SpecVersion1_4 {
-				if d.bom.Metadata.Tools.Components == nil {
-					d.bom.Metadata.Tools.Components = &[]cydx.Component{}
-				}
-
-				*d.bom.Metadata.Tools.Components = append(*d.bom.Metadata.Tools.Components, *choice.Components...)
-			} else {
-				if d.bom.Metadata.Tools.Tools == nil {
-					d.bom.Metadata.Tools.Tools = &[]cydx.Tool{}
-				}
-				*d.bom.Metadata.Tools.Tools = append(*d.bom.Metadata.Tools.Tools, *choice.Tools...)
-			}
+			d.bom.Metadata.Tools = cdxUniqTools(d.bom.Metadata.Tools, choice)
 		} else {
 			d.bom.Metadata.Tools = choice
 		}

--- a/pkg/edit/config.go
+++ b/pkg/edit/config.go
@@ -20,8 +20,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-
-	"sigs.k8s.io/release-utils/version"
 )
 
 var supportedSubjects map[string]bool = map[string]bool{
@@ -244,12 +242,6 @@ func convertToConfigParams(eParams *EditParams) (*configParams, error) {
 			value: version,
 		})
 	}
-
-	// Always add SBOMASM to the tool list
-	p.tools = append(p.tools, paramTuple{
-		name:  "sbomasm",
-		value: version.GetVersionInfo().GitVersion,
-	})
 
 	p.copyright = eParams.CopyRight
 	p.lifecycles = eParams.Lifecycles

--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -361,22 +361,7 @@ func (d *spdxEditDoc) tools() error {
 		return errNotSupported
 	}
 
-	tools := []spdx.Creator{}
-	uniqTools := make(map[string]bool)
-
-	for _, tool := range d.c.tools {
-		parts := []string{tool.name, tool.value}
-		key := fmt.Sprintf("%s-%s", strings.ToLower(tool.name), strings.ToLower(tool.value))
-
-		if _, ok := uniqTools[key]; !ok {
-			tools = append(tools, spdx.Creator{
-				CreatorType: "Tool",
-				Creator:     strings.Join(lo.Compact(parts), "-"),
-			})
-
-			uniqTools[key] = true
-		}
-	}
+	tools := spdxConstructTools(d.bom, d.c)
 
 	if d.c.onMissing() {
 		if d.bom.CreationInfo == nil {
@@ -396,7 +381,8 @@ func (d *spdxEditDoc) tools() error {
 		} else if d.bom.CreationInfo.Creators == nil {
 			d.bom.CreationInfo.Creators = tools
 		} else {
-			d.bom.CreationInfo.Creators = append(d.bom.CreationInfo.Creators, tools...)
+			//d.bom.CreationInfo.Creators = append(d.bom.CreationInfo.Creators, tools...)
+			d.bom.CreationInfo.Creators = spdxUniqueTools(d.bom.CreationInfo.Creators, tools)
 		}
 	} else {
 		if d.bom.CreationInfo == nil {


### PR DESCRIPTION
- Added ability to list only unique tools as duplicates we causing an issue.
- Removed adding sbomasm to the tool list. This is a temporary removal, as the current method is buggy.  Will re-add when auto-annotation is supported. 