### PR TITLE
handle nil pointer

### DIFF
--- a/pkg/assemble/cdx/util.go
+++ b/pkg/assemble/cdx/util.go
@@ -211,7 +211,7 @@ func buildToolList(in []*cydx.BOM) *cydx.ToolsChoice {
 	})
 
 	for _, bom := range in {
-		if bom.Metadata != nil && bom.Metadata.Tools != nil {
+		if bom.Metadata != nil && bom.Metadata.Tools != nil && bom.Metadata.Tools.Tools != nil {
 			for _, tool := range *bom.Metadata.Tools.Tools {
 				*tools.Components = append(*tools.Components, cydx.Component{
 					Type:    cydx.ComponentTypeApplication,


### PR DESCRIPTION
closes #116 

This PR addresses the issue of attempting to access a pointer that is nil, specifically when `metadata.tools.tools` is nil, which results in an error being thrown.