### PR TITLE
fix: remove duplicate packages from final package list

### DIFF
--- a/pkg/assemble/cdx/uniq_comp_service.go
+++ b/pkg/assemble/cdx/uniq_comp_service.go
@@ -27,10 +27,10 @@ import (
 
 type uniqueComponentService struct {
 	ctx context.Context
-	//unique list of new components
+	// unique list of new components
 	compMap map[string]*cydx.Component
 
-	//mapping from old component id to new component id
+	// mapping from old component id to new component id
 	idMap map[string]string
 }
 

--- a/pkg/assemble/spdx/merge.go
+++ b/pkg/assemble/spdx/merge.go
@@ -17,8 +17,6 @@
 package spdx
 
 import (
-	"fmt"
-
 	"github.com/google/uuid"
 	"github.com/interlynk-io/sbomasm/pkg/logger"
 	"github.com/spdx/tools-golang/spdx"
@@ -103,13 +101,6 @@ func (m *merge) combinedMerge() error {
 	// Add Packages to document
 	doc.Packages = append(doc.Packages, primaryPkg)
 	doc.Packages = append(doc.Packages, pkgs...)
-
-	doc.Packages = removeDuplicates(doc.Packages)
-
-	for _, p := range doc.Packages {
-		fmt.Println("DOC PACKAGE NAME: ", p.PackageName)
-		fmt.Println("DOC VERSION NAME: ", p.PackageVersion)
-	}
 
 	// Add Files to document
 	doc.Files = append(doc.Files, files...)

--- a/pkg/assemble/spdx/merge.go
+++ b/pkg/assemble/spdx/merge.go
@@ -17,6 +17,8 @@
 package spdx
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/interlynk-io/sbomasm/pkg/logger"
 	"github.com/spdx/tools-golang/spdx"
@@ -98,14 +100,21 @@ func (m *merge) combinedMerge() error {
 
 	describedPkgs := getDescribedPkgs(m)
 
-	//Add Packages to document
+	// Add Packages to document
 	doc.Packages = append(doc.Packages, primaryPkg)
 	doc.Packages = append(doc.Packages, pkgs...)
 
-	//Add Files to document
+	doc.Packages = removeDuplicates(doc.Packages)
+
+	for _, p := range doc.Packages {
+		fmt.Println("DOC PACKAGE NAME: ", p.PackageName)
+		fmt.Println("DOC VERSION NAME: ", p.PackageVersion)
+	}
+
+	// Add Files to document
 	doc.Files = append(doc.Files, files...)
 
-	//Add OtherLicenses to document
+	// Add OtherLicenses to document
 	doc.OtherLicenses = append(doc.OtherLicenses, otherLicenses...)
 
 	topLevelRels := []*spdx.Relationship{}
@@ -140,13 +149,13 @@ func (m *merge) combinedMerge() error {
 		}
 	}
 
-	//Add Relationships to document
+	// Add Relationships to document
 	doc.Relationships = append(doc.Relationships, topLevelRels...)
 	if len(rels) > 0 {
 		doc.Relationships = append(doc.Relationships, rels...)
 	}
 
-	//Write the SBOM
+	// Write the SBOM
 	err = writeSBOM(doc, m)
 
 	return err


### PR DESCRIPTION
closes: https://github.com/interlynk-io/sbomasm/issues/101

This PR resolves the duplicate packages from final package list. It identifies the duplicacy of package by following:

```
PURL match: If the PURL matches, it's a duplicate; no need to check further.
CPE match: If the CPE matches, it's a duplicate; no need to check further.
Name-Version match: If the Name and Version match, it's a duplicate; no need to check further.
Checksum match: If the Checksum matches, it's a duplicate; no need to check further.
```
Reference: https://github.com/interlynk-io/sbomasm/issues/101#issuecomment-2326965065

**TODO**: To test against some more SBOMs. 