### PR TITLE
fix: Fix nil value on old component

### DIFF
--- a/pkg/assemble/cdx/merge.go
+++ b/pkg/assemble/cdx/merge.go
@@ -121,6 +121,11 @@ func (m *merge) combinedMerge() error {
 				oldPc = b.Metadata.Component
 			}
 
+			if oldPc == nil {
+				log.Error("hierarchical merge: old product does not have any component.")
+				oldPc = &cydx.Component{}
+			}
+
 			newPcId, _ := cs.ResolveDepID(oldPc.BOMRef)
 
 			for i, pc := range priCompList {


### PR DESCRIPTION
When the oldPc does not have a component it produces an error. This checks for it its nil and creates an empty component to work with.