### PR TITLE
fix: nil panic in assemble

### DIFF
--- a/pkg/assemble/cdx/util.go
+++ b/pkg/assemble/cdx/util.go
@@ -289,7 +289,7 @@ func buildDependencyList(in []*cydx.BOM, cs *uniqueComponentService) []cydx.Depe
 				continue
 			}
 
-			if len(*dep.Dependencies) == 0 {
+			if len(lo.FromPtr(dep.Dependencies)) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
Fixes nil panic when `*deps.Dependencies` is `nil`.

This update includes a signed commit, as per the request in https://github.com/interlynk-io/sbomasm/pull/121

```shell
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x85cb6e]

goroutine 1 [running]:
github.com/interlynk-io/sbomasm/pkg/assemble/cdx.buildDependencyList.func1(0x46959d?, 0x7924a4?)
	/home/user/p/play/sbomasm/pkg/assemble/cdx/util.go:292 +0xee
github.com/samber/lo.Map[...]({0xc000b75d00?, 0x5, 0x18}, 0xc00110f620?)
	/home/user/go/pkg/mod/github.com/samber/lo@v1.47.0/slice.go:30 +0x73
github.com/interlynk-io/sbomasm/pkg/assemble/cdx.buildDependencyList({0xc000b75d00?, 0xab400e?, 0x5?}, 0xc00110faf0?)
	/home/user/p/play/sbomasm/pkg/assemble/cdx/util.go:283 +0x4a
github.com/interlynk-io/sbomasm/pkg/assemble/cdx.(*merge).combinedMerge(0xc00110fb98)
	/home/user/p/play/sbomasm/pkg/assemble/cdx/merge.go:74 +0x3a5
github.com/interlynk-io/sbomasm/pkg/assemble/cdx.Merge(0xc0002e2480)
	/home/user/p/play/sbomasm/pkg/assemble/cdx/interface.go:143 +0x1a9
github.com/interlynk-io/sbomasm/pkg/assemble.(*combiner).combine(0xc00110fc30)
	/home/user/p/play/sbomasm/pkg/assemble/combiner.go:45 +0xb7
github.com/interlynk-io/sbomasm/pkg/assemble.Assemble(0xc0002e2180)
	/home/user/p/play/sbomasm/pkg/assemble/interface.go:69 +0x47
github.com/interlynk-io/sbomasm/cmd.init.func1(0x10a7760, {0xc0003f8510, 0x5, 0x9})
	/home/user/p/play/sbomasm/cmd/assemble.go:69 +0x1c8
github.com/spf13/cobra.(*Command).execute(0x10a7760, {0xc0003f8480, 0x9, 0x9})
	/home/user/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0x10a82e0)
	/home/user/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/user/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/interlynk-io/sbomasm/cmd.Execute()
	/home/user/p/play/sbomasm/cmd/root.go:47 +0x1f
main.main()
	/home/user/p/play/sbomasm/main.go:21 +0xf
```