### PR TITLE
disable version check by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,4 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 # Copy our static executable
 COPY --from=builder /app/build/sbomasm /app/sbomasm
 
-# Disable version check
-ENV INTERLYNK_DISABLE_VERSION_CHECK=true
-
 ENTRYPOINT [ "/app/sbomasm" ]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ sbomasm assemble -n "mega cdx app" -v "1.0.0" -t "application" -o final-product.
 ```
 `sbomasm` in an AirGapped Environment
 ```sh
-INTERLYNK_DISABLE_VERSION_CHECK=true sbomasm assemble -n "mega cdx app" -v "1.0.0" -t "application" -o final-product.cdx.json sbom1.json sbom2.json sbom3.json
+INTERLYNK_VERSION_CHECK=true sbomasm assemble -n "mega cdx app" -v "1.0.0" -t "application" -o final-product.cdx.json sbom1.json sbom2.json sbom3.json
 ```
 `sbomasm` via containers
 ```sh

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,7 @@ func init() {
 }
 
 func checkIfLatestRelease() {
-	if os.Getenv("INTERLYNK_DISABLE_VERSION_CHECK") != "" {
+	if os.Getenv("INTERLYNK_VERSION_CHECK") == "" {
 		return
 	}
 


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomasm/issues/124

This PR disable version check by default. Earlier it was enabled by default. So, now version check will be enabled only if it is explicity provided/feeded. For example:

`export INTERLYNK_VERSION_CHECK=true`