### PR TITLE
flexibility on overriding config values

### DIFF
--- a/cmd/assemble.go
+++ b/cmd/assemble.go
@@ -54,6 +54,18 @@ Advanced Example:
 
 		ctx := logger.WithLogger(context.Background())
 
+		configPath, _ := cmd.Flags().GetString("configPath")
+		name, _ := cmd.Flags().GetString("name")
+		version, _ := cmd.Flags().GetString("version")
+		typeValue, _ := cmd.Flags().GetString("type")
+
+		if configPath == "" {
+			// if no config file, all grouped flags are required
+			if name == "" || version == "" || typeValue == "" {
+				return fmt.Errorf("if no config file is provided, flags --name, --version, and --type must all be set")
+			}
+		}
+
 		assembleParams, err := extractArgs(cmd, args)
 		if err != nil {
 			return err
@@ -78,7 +90,6 @@ func init() {
 	assembleCmd.Flags().StringP("name", "n", "", "name of the assembled sbom")
 	assembleCmd.Flags().StringP("version", "v", "", "version of the assembled sbom")
 	assembleCmd.Flags().StringP("type", "t", "", "product type of the assembled sbom (application, framework, library, container, device, firmware)")
-	assembleCmd.MarkFlagsRequiredTogether("name", "version", "type")
 
 	assembleCmd.Flags().BoolP("flatMerge", "f", false, "flat merge")
 	assembleCmd.Flags().BoolP("hierMerge", "m", false, "hierarchical merge")


### PR DESCRIPTION
close: https://github.com/interlynk-io/sbomasm/issues/125

This PR provides the flexibility to override any individual field (e.g., just "version") without being required to provide all the other grouped fields. If any value along with config file are provides, then those flag value will be prioritize over config default values.

**For example:**
- override version value from config value:
  ```bash
  $ sbomasm assemble -v "v2.2.2" -c config.yaml -o final-sbom-config.spdx.json sbomex-cdx.json sbomgr-cdx.json
  ```
- override name, type, version values from config values:
  ```bash
  $ sbomasm assemble -v "v1.0.20" -n "bob"  -t "library"  -c config.yaml -o final-sbom-config.spdx.json sbomex-cdx.json sbomgr-cdx.json
  ```
  
  To understand issue more detail, see [here](https://github.com/interlynk-io/sbomasm/issues/125#issuecomment-2566896970)
