### PR TITLE
return err on editing missing primarycomp or any comp

### DIFF
--- a/pkg/edit/cdx.go
+++ b/pkg/edit/cdx.go
@@ -60,9 +60,9 @@ func cdxEdit(c *configParams) error {
 		return err
 	}
 
-	doc := NewCdxEditDoc(bom, c)
+	doc, err := NewCdxEditDoc(bom, c)
 	if doc == nil {
-		return errors.New("failed to create edit document")
+		return fmt.Errorf("failed to edit cdx document: %w", err)
 	}
 
 	if c.shouldSearch() && doc.comp == nil {
@@ -120,7 +120,7 @@ func loadCdxBom(ctx context.Context, path string) (*cydx.BOM, error) {
 func writeCdxBom(bom *cydx.BOM, c *configParams) error {
 	var f io.Writer
 
-	//Always generate a new serial number on edit
+	// Always generate a new serial number on edit
 	bom.SerialNumber = newCdxSerialNumber()
 
 	if c.outputFilePath == "" {

--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -15,21 +15,27 @@ type cdxEditDoc struct {
 	c    *configParams
 }
 
-func NewCdxEditDoc(b *cydx.BOM, c *configParams) *cdxEditDoc {
+func NewCdxEditDoc(b *cydx.BOM, c *configParams) (*cdxEditDoc, error) {
 	doc := &cdxEditDoc{}
 
 	doc.bom = b
 	doc.c = c
 
 	if c.search.subject == "primary-component" {
+		if b.Metadata.Component == nil {
+			return nil, fmt.Errorf("primary component is missing")
+		}
 		doc.comp = b.Metadata.Component
 	}
 
 	if c.search.subject == "component-name-version" {
 		doc.comp = cdxFindComponent(b, c)
+		if doc.comp == nil {
+			return nil, fmt.Errorf("component is missing")
+		}
 	}
 
-	return doc
+	return doc, nil
 }
 
 func (d *cdxEditDoc) update() {

--- a/pkg/edit/spdx.go
+++ b/pkg/edit/spdx.go
@@ -58,9 +58,9 @@ func spdxEdit(c *configParams) error {
 		return err
 	}
 
-	doc := NewSpdxEditDoc(bom, c)
+	doc, err := NewSpdxEditDoc(bom, c)
 	if doc == nil {
-		return errors.New("failed to create spdx edit document")
+		return fmt.Errorf("failed to edit spdx document: %w", err)
 	}
 
 	doc.update()

--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -20,13 +20,16 @@ type spdxEditDoc struct {
 	c   *configParams
 }
 
-func NewSpdxEditDoc(bom *spdx.Document, c *configParams) *spdxEditDoc {
+func NewSpdxEditDoc(bom *spdx.Document, c *configParams) (*spdxEditDoc, error) {
 	doc := &spdxEditDoc{}
 
 	doc.bom = bom
 	doc.c = c
 
 	if c.search.subject == "primary-component" {
+		if doc.pkg == nil {
+			return nil, fmt.Errorf("primary package is missing")
+		}
 		pkg, err := spdxFindPkg(bom, c, true)
 		if err == nil {
 			doc.pkg = pkg
@@ -34,12 +37,16 @@ func NewSpdxEditDoc(bom *spdx.Document, c *configParams) *spdxEditDoc {
 	}
 
 	if c.search.subject == "component-name-version" {
+
 		pkg, err := spdxFindPkg(bom, c, false)
 		if err == nil {
 			doc.pkg = pkg
 		}
+		if doc.pkg == nil {
+			return nil, fmt.Errorf("package is missing")
+		}
 	}
-	return doc
+	return doc, nil
 }
 
 func (d *spdxEditDoc) update() {


### PR DESCRIPTION
closes: https://github.com/interlynk-io/sbomasm/issues/146

This PR adds the following changes:
- For both spdx and cdx:
  - If it performs editing on missing element.
  - For ex:
    - when tries to edit subject: `primary-component`, and primary comp is missing, then it throws an error that "it fails to edit missing primary comp"
    - simialrly, when sub : `component-name-version`, and that component is missing, then it throws and error that "it fails to edit missing comp"
    
  - In both cases, throws an error on editing missing element.