### PR TITLE
customize sbomasm version accordingly

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import "sigs.k8s.io/release-utils/version"
+
+var Version = version.GetVersionInfo().GitVersion

--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/interlynk-io/sbomasm/internal/version"
 	"github.com/interlynk-io/sbomasm/pkg/logger"
 	"github.com/samber/lo"
 	"github.com/spdx/tools-golang/spdx"
 )
 
 const (
-	SBOMASM         = "sbomasm"
-	SBOMASM_VERSION = "0.1.9"
+	SBOMASM = "sbomasm"
 )
+
+var SBOMASM_VERSION = version.Version
 
 type spdxEditDoc struct {
 	bom *spdx.Document


### PR DESCRIPTION
This PR adds the following changes:
- Set the `SBOMASM_VERSION` by exporting it.

```bash
.../sbomasm on 🌿 fix/issue_152 [$?] via 🔵🦦🔵 v1.23.1  via 💎 v3.2.0 
$ export SBOMASM_VERSION=0.0.3; go run main.go edit --append --subject document --tool 'trivy (0.56.1)' --tool 'parlay (0.5.1)' --tool 'bomctl (v0.4.1)' samples/spdx/issue-67/example6-bin.spdx   --output expected1.spdx.json


.../sbomasm on 🌿 fix/issue_152 [$?] via 🔵🦦🔵 v1.23.1  via 💎 v3.2.0 
➜ cat expected1.spdx.json 
SPDXVersion: SPDX-2.3
DataLicense: CC0-1.0
SPDXID: SPDXRef-DOCUMENT
DocumentName: hello-go-bin
DocumentNamespace: https://swinslow.net/spdx-examples/example6/hello-go-bin-v2
ExternalDocumentRef: DocumentRef-go-lib https://swinslow.net/spdx-examples/example6/go-lib-v2 SHA1:58e4a6d5745f032b9788142e49edee1b508c7ac5
ExternalDocumentRef: DocumentRef-hello-go-src https://swinslow.net/spdx-examples/example6/hello-go-src-v2 SHA1:b3018ddb18802a56b60ad839c98d279687b60bd6
LicenseListVersion: 3.18
Creator: Person: Steve Winslow (steve@swinslow.net)
Creator: Tool: github.com/spdx/tools-golang/builder
Creator: Tool: github.com/spdx/tools-golang/idsearcher
Creator: Tool: trivy-0.56.1
Creator: Tool: parlay-0.5.1
Creator: Tool: bomctl-v0.4.1
Creator: Tool: sbomasm-0.0.3
Created: 2021-08-26T01:56:00Z

```