### PR TITLE
update timestamp on any operation

### DIFF
--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -93,17 +93,7 @@ func (d *cdxEditDoc) timeStamp() error {
 		return errNoConfiguration
 	}
 
-	if d.c.search.subject != "document" {
-		return errNotSupported
-	}
-
-	if d.c.onMissing() {
-		if d.bom.Metadata.Timestamp == "" {
-			d.bom.Metadata.Timestamp = utcNowTime()
-		}
-	} else {
-		d.bom.Metadata.Timestamp = utcNowTime()
-	}
+	d.bom.Metadata.Timestamp = utcNowTime()
 	return nil
 }
 

--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -572,25 +572,11 @@ func (d *spdxEditDoc) timeStamp() error {
 		return errNoConfiguration
 	}
 
-	if d.c.search.subject != "document" {
-		return errNotSupported
+	if d.bom.CreationInfo == nil {
+		d.bom.CreationInfo = &spdx.CreationInfo{}
 	}
+	d.bom.CreationInfo.Created = utcNowTime()
 
-	if d.c.onMissing() {
-		if d.bom.CreationInfo == nil {
-			d.bom.CreationInfo = &spdx.CreationInfo{}
-		}
-
-		if d.bom.CreationInfo.Created == "" {
-			d.bom.CreationInfo.Created = utcNowTime()
-		}
-	} else {
-		if d.bom.CreationInfo == nil {
-			d.bom.CreationInfo = &spdx.CreationInfo{}
-		}
-
-		d.bom.CreationInfo.Created = utcNowTime()
-	}
 	return nil
 }
 


### PR DESCRIPTION
The PR updates the following changes:
- Earlier `timestamp` was only updated when subject was document, but not it's regardless of the subject. 
- Earlier timestamp was also updated on the basis of specific operation i.e. `missing`. But, it should be update regardless of operation.