### PR TITLE
Fix/missing values in edit operation

### DIFF
--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -587,7 +587,7 @@ func (d *cdxEditDoc) purl() error {
 	}
 
 	if d.c.onMissing() {
-		if d.comp.PackageURL == "" {
+		if d.comp.PackageURL == "" || d.comp.PackageURL != d.c.purl {
 			d.comp.PackageURL = d.c.purl
 		}
 	} else {

--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -228,22 +228,22 @@ func (d *spdxEditDoc) purl() error {
 		Locator:  d.c.purl,
 	}
 
-	foundPurl := false
+	foundPurlWithKeyAndValue := false
 	for _, ref := range d.pkg.PackageExternalReferences {
-		if ref.RefType == "purl" {
-			foundPurl = true
+		if ref.RefType == "purl" && ref.Locator == d.c.purl {
+			foundPurlWithKeyAndValue = true
 		}
 	}
 
 	if d.c.onMissing() {
-		if !foundPurl {
+		if !foundPurlWithKeyAndValue {
 			if d.pkg.PackageExternalReferences == nil {
 				d.pkg.PackageExternalReferences = []*spdx.PackageExternalReference{}
 			}
 			d.pkg.PackageExternalReferences = append(d.pkg.PackageExternalReferences, &purl)
 		}
 	} else if d.c.onAppend() {
-		if !foundPurl {
+		if !foundPurlWithKeyAndValue {
 			if d.pkg.PackageExternalReferences == nil {
 				d.pkg.PackageExternalReferences = []*spdx.PackageExternalReference{}
 			}


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomasm/issues/172

This PR adds the following changes:
- It adds the values corresponding to the field, if that value is missing.

For example, 
purl with a value `abc` is present in SBOM, and a purl with a `xyz` is trying to add in the `missing` edit operation, then:
- for SPDX: it will be appended as `xyz`
```json
    "externalRefs": [
        {
         "referenceCategory": "PACKAGE-MANAGER",
         "referenceType": "purl",
         "referenceLocator": "pkg:abc"
        },
        {
         "referenceCategory": "PACKAGE-MANAGER",
         "referenceType": "purl",
         "referenceLocator": "pkg:xyz"
        }
       ]
```
    
- fox CDX: it will be replaced by `xyz`

    ```json
    "purl": "pkg:xyz"
    ```

