### PR TITLE
add supplier for spdx doc

### DIFF
--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	SBOMASM = "sbomasm"
+	SBOMASM               = "sbomasm"
+	SupplierPrefixComment = "The supplier of this document are "
 )
 
 var SBOMASM_VERSION = version.Version
@@ -145,8 +146,27 @@ func (d *spdxEditDoc) supplier() error {
 		return errNoConfiguration
 	}
 
+	comment := ""
+	comment += fmt.Sprintf("%s (%s)", d.c.supplier.name, d.c.supplier.value)
+
 	if d.c.search.subject == "document" {
-		return errNotSupported
+		// add creator comment
+		if d.bom.CreationInfo == nil {
+			d.bom.CreationInfo = &spdx.CreationInfo{
+				CreatorComment: SupplierPrefixComment + comment,
+			}
+		} else {
+			if d.bom.CreationInfo.CreatorComment == "" {
+				d.bom.CreationInfo.CreatorComment = SupplierPrefixComment + comment
+			} else {
+				if !strings.Contains(d.bom.CreationInfo.CreatorComment, SupplierPrefixComment) {
+					d.bom.CreationInfo.CreatorComment += fmt.Sprintf("\n\n"+SupplierPrefixComment+"%s", comment)
+				} else {
+					d.bom.CreationInfo.CreatorComment += fmt.Sprintf(", "+"%s", comment)
+				}
+			}
+		}
+		return nil
 	}
 
 	supplier := spdx.Supplier{


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomasm/issues/173

This PR adds the following changes:
- It adds the supplier field for SPDX doc at `CreationInfo->Creator->Comment`

```bash
 go run main.go edit --subject Document  --supplier "fooler (https://fooler.com)"  --output update-doc-with-supplier.spdx.json  sbomqs-linux-amd64.spdx.sbom.json
 ```
 o/p SBOM would contain:
 
Examples:
```json
 "creationInfo": {
  "licenseListVersion": "3.25",
  "creators": [
   "Organization: Anchore, Inc",
   "Tool: syft-1.26.1",
   "Tool: sbomasm-devel"
  ],
  "created": "2025-06-30T14:03:27Z",
  "comment": "The supplier of this document are fooler (https://fooler.com)"
 },

```