### PR TITLE
add author in append edit operation when not present

### DIFF
--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -707,7 +707,11 @@ func (d *cdxEditDoc) authors() error {
 		}
 	} else if d.c.onAppend() {
 		if d.c.search.subject == "document" {
-			*d.bom.Metadata.Authors = append(*d.bom.Metadata.Authors, *authors...)
+			if d.bom.Metadata.Authors == nil {
+				d.bom.Metadata.Authors = authors
+			} else {
+				*d.bom.Metadata.Authors = append(*d.bom.Metadata.Authors, *authors...)
+			}
 		} else {
 			if d.bom.SpecVersion <= cydx.SpecVersion1_5 {
 				d.comp.Author = d.c.getFormattedAuthors()


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomasm/issues/174

This PR adds the following changes:
- Add the author for append edit operation in case when no author is present

For example:
```bash
go run main.go  edit --subject Document  --author "foo (foo@gmail.com)" --append  --output append-empty-list-add-author.sbom.cdx.json  sbom-with-no-author.cdx.json
```

o/p:
```json
"authors": [
      {
        "bom-ref": "sbomasm:dec4744a-0a82-4a22-bf5c-3c56052e536d",
        "name": "foo",
        "email": "foo@gmail.com"
      }
    ],

```

Earlier, when no author was present, and tries to add it using append operation, it throes an error.