### PR TITLE
overwrite all cpe by new cpe in edit default operation

### DIFF
--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -314,7 +314,7 @@ func (d *spdxEditDoc) cpe() error {
 			d.pkg.PackageExternalReferences = append(d.pkg.PackageExternalReferences, &cpe)
 		} else {
 			extRef := lo.Reject(d.pkg.PackageExternalReferences, func(x *spdx.PackageExternalReference, _ int) bool {
-				return strings.ToLower(x.RefType) == "cpe23Type"
+				return strings.ToLower(x.RefType) == "cpe23type"
 			})
 
 			if extRef == nil {


### PR DESCRIPTION
Closes https://github.com/interlynk-io/sbomasm/issues/175

This PR adds the following changes:
- It overwrites all existing CPEs with new CPE.

For example:
Earlier CPEs containing SBOM:
```json
 "externalRefs": [
    {
     "referenceCategory": "SECURITY",
     "referenceType": "cpe23Type",
     "referenceLocator": "cpe:2.3:a:olekukonko:tablewriter:v0.0.5:*:*:*:*:*:*:*"
    },
    {
     "referenceCategory": "PACKAGE-MANAGER",
     "referenceType": "purl",
     "referenceLocator": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5"
    },
    {
     "referenceCategory": "SECURITY",
     "referenceType": "cpe23Type",
     "referenceLocator": "cpe:2.3:a:bar:tablewriter:v0.0.5:*:*:*:*:*:*:*"
    },
    {
     "referenceCategory": "SECURITY",
     "referenceType": "cpe23Type",
     "referenceLocator": "cpe:2.3:a:bar:tablewriter:v0.0.5:*:*:*:*:*:*:*"
    }
   ]
  },

```

Now, after running command:
```bash
go run main.go edit --subject component-name-version --search "github.com/olekukonko/tablewriter (v0.0.5)" --cpe "cpe:2.3:a:bar:tablewriter:v0.0.5:*:*:*:*:*:*:*"  --timestamp --output replace-all-cpe-by-one-cpe-sbom.spdx.json sbom-with-three-cpes.spdx.json
```

o/p of CPE in new SBOM:
```json
"externalRefs": [
    {
     "referenceCategory": "PACKAGE-MANAGER",
     "referenceType": "purl",
     "referenceLocator": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5"
    },
    {
     "referenceCategory": "SECURITY",
     "referenceType": "cpe23Type",
     "referenceLocator": "cpe:2.3:a:bar:tablewriter:v0.0.5:*:*:*:*:*:*:*"
    }
   ]

```