### PR TITLE
Fix/sbomasm enrichment revision

### DIFF
--- a/cmd/enrich.go
+++ b/cmd/enrich.go
@@ -56,8 +56,9 @@ func init() {
 	enrichCmd.Flags().StringP("output", "o", "", "Output path of file to save the enriched SBOM")
 	enrichCmd.Flags().BoolP("debug", "d", false, "Enable debug logging")
 	enrichCmd.Flags().BoolP("force", "f", false, "Forcefully replace the existing fields with new one.")
-	enrichCmd.Flags().IntP("max-retries", "r", 2, "Maximum number of retries for failed requests(default: 2)")
+	enrichCmd.Flags().IntP("max-retries", "r", 2, "Maximum number of retries for failed requests (default: 2)")
 	enrichCmd.Flags().IntP("max-wait", "w", 5, "Maximum wait time for requests(default: 5sec)")
+	enrichCmd.Flags().StringP("license-exp-join", "j", "OR", "Join license expressions by operator (default: OR), e.g. 'AND', 'WITH', '+'")
 }
 
 func runEnrich(cmd *cobra.Command, args []string) error {
@@ -115,6 +116,9 @@ func extractEnrichConfig(cmd *cobra.Command, args []string) (*enrich.Config, err
 
 	maxWait, _ := cmd.Flags().GetInt("max-wait")
 	enrichConfig.MaxWait = time.Duration(maxWait) * time.Second
+
+	licenseExpJoinBy, _ := cmd.Flags().GetString("license-exp-join")
+	enrichConfig.LicenseExpressionJoinBy = licenseExpJoinBy
 
 	force, _ := cmd.Flags().GetBool("force")
 	enrichConfig.Force = force

--- a/cmd/enrich.go
+++ b/cmd/enrich.go
@@ -90,7 +90,7 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to run enrich engine: %w", err)
 	}
 
-	fmt.Printf("\nEnriched: %d, Skipped: %d, Failed: %d\n", summary.Enriched, summary.Skipped, summary.Failed)
+	fmt.Printf("\nTotal: %d, Selected: %d, Enriched: %d, Skipped: %d, Failed: %d\n", summary.TotalComponents, summary.SelectedComponents, summary.Enriched, summary.Skipped, summary.Failed)
 
 	for _, err := range summary.Errors {
 		fmt.Printf("Error: %v\n", err)

--- a/pkg/enrich/clearlydef/client.go
+++ b/pkg/enrich/clearlydef/client.go
@@ -125,10 +125,11 @@ func Client(ctx context.Context, componentsToCoordinateMappings map[interface{}]
 
 		if end > len(coordList) {
 			end = len(coordList)
-			fmt.Printf("Processing components: %d of %d\n", end, len(coordList))
+			fmt.Printf("Processing components For Response: %d of %d\n", end, len(coordList))
 
+		} else {
+			fmt.Printf("Processing Components For Response: %d of %d\n", end, len(coordList))
 		}
-		fmt.Printf("Processing Components For Request: %d of %d\n", end, len(coordList))
 
 		chunk := coordList[i:end]
 

--- a/pkg/enrich/clearlydef/client.go
+++ b/pkg/enrich/clearlydef/client.go
@@ -125,10 +125,10 @@ func Client(ctx context.Context, componentsToCoordinateMappings map[interface{}]
 
 		if end > len(coordList) {
 			end = len(coordList)
-			fmt.Printf("\nProcessing components: %d of %d\n", end, len(coordList))
+			fmt.Printf("Processing components: %d of %d\n", end, len(coordList))
 
 		}
-		fmt.Printf("\nProcessing components: %d of %d\n", end, len(coordList))
+		fmt.Printf("Processing Components For Request: %d of %d\n", end, len(coordList))
 
 		chunk := coordList[i:end]
 

--- a/pkg/enrich/clearlydef/mapper.go
+++ b/pkg/enrich/clearlydef/mapper.go
@@ -27,18 +27,6 @@ import (
 	"github.com/spdx/tools-golang/spdx"
 )
 
-type PKG_TYPE string
-
-const (
-	NPM   PKG_TYPE = "npm"
-	GO    PKG_TYPE = "golang"
-	PYPI  PKG_TYPE = "pypi"
-	MAVEN PKG_TYPE = "maven"
-	NUGET PKG_TYPE = "nuget"
-	GEM   PKG_TYPE = "gem"
-	DEB   PKG_TYPE = "deb"
-)
-
 type Coordinate struct {
 	Type      string
 	Provider  string

--- a/pkg/enrich/engine.go
+++ b/pkg/enrich/engine.go
@@ -61,6 +61,9 @@ func Engine(ctx context.Context, params *Config) (*EnrichSummary, error) {
 		return summary, nil
 	}
 
+	summary.TotalComponents = total
+	summary.SelectedComponents = selected
+
 	// map the component to a clearlydefined coordinates
 	componentsToCoordinateMappings := clearlydef.Mapper(ctx, components)
 
@@ -71,7 +74,7 @@ func Engine(ctx context.Context, params *Config) (*EnrichSummary, error) {
 	}
 
 	// enrich the sbom
-	sbomDoc, enriched, skipped, skippedReasons, err := Enricher(ctx, sbomDoc, components, responses, params.Force)
+	sbomDoc, enriched, skipped, skippedReasons, err := Enricher(ctx, sbomDoc, components, responses, params.Force, params.LicenseExpressionJoinBy)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/enrich/engine.go
+++ b/pkg/enrich/engine.go
@@ -33,6 +33,8 @@ func Engine(ctx context.Context, params *Config) (*EnrichSummary, error) {
 	log := logger.FromContext(ctx)
 	log.Debugf("starting enrich engine")
 
+	summary := NewEnrichSummary()
+
 	// parse the SBOM document
 	sbomDoc, err := sbom.Parser(ctx, params.SBOMFile)
 	if err != nil {
@@ -46,9 +48,17 @@ func Engine(ctx context.Context, params *Config) (*EnrichSummary, error) {
 		Force:  params.Force,
 	}
 
-	components, err := extract.Components(ctx, sbomDoc, extractParams)
+	components, total, selected, err := extract.Components(ctx, sbomDoc, extractParams)
 	if err != nil {
 		return nil, err
+	}
+
+	// if no components were found, return early
+	// if no components selected return early
+	if total == 0 || selected == 0 {
+		summary.TotalComponents = total
+		summary.SelectedComponents = selected
+		return summary, nil
 	}
 
 	// map the component to a clearlydefined coordinates
@@ -71,24 +81,11 @@ func Engine(ctx context.Context, params *Config) (*EnrichSummary, error) {
 		return nil, err
 	}
 
-	summary := calculateSummary(ctx, enriched, skipped, skippedReasons)
+	summary.Enriched = enriched
+	summary.Skipped = skipped
+	summary.SkippedReasons = skippedReasons
 
-	return &summary, nil
-}
-
-// calculateSummary counts enriched/skipped/failed components
-func calculateSummary(ctx context.Context, enriched, skipped int, skippedReasons map[string]string) EnrichSummary {
-	log := logger.FromContext(ctx)
-	log.Debugf("enrichment summary: Enriched: %d, Skipped: %d", enriched, skipped)
-
-	summary := EnrichSummary{
-		Enriched:       enriched,
-		Skipped:        skipped,
-		SkippedReasons: skippedReasons,
-		Failed:         0,
-		Errors:         nil,
-	}
-	return summary
+	return summary, nil
 }
 
 func processOutput(ctx context.Context, sbomDoc sbom.SBOMDocument, params *Config) error {

--- a/pkg/enrich/enrich.go
+++ b/pkg/enrich/enrich.go
@@ -60,7 +60,7 @@ func isLicenseExpression(license string) bool {
 }
 
 // Enricher updates licenses in the SBOM
-func Enricher(ctx context.Context, sbomDoc sbom.SBOMDocument, components []interface{}, responses map[interface{}]clearlydef.DefinitionResponse, force bool) (sbom.SBOMDocument, int, int, map[string]string, error) {
+func Enricher(ctx context.Context, sbomDoc sbom.SBOMDocument, components []interface{}, responses map[interface{}]clearlydef.DefinitionResponse, force bool, licenseExpJoinBy string) (sbom.SBOMDocument, int, int, map[string]string, error) {
 	log := logger.FromContext(ctx)
 	fmt.Printf("\nEnriching SBOM...\n")
 
@@ -174,9 +174,9 @@ func Enricher(ctx context.Context, sbomDoc sbom.SBOMDocument, components []inter
 					log.Debugf("Added declared license %s to %s@%s\n", compWithCorrespondingDefResponse.Licensed.Declared, c.Name, c.Version)
 				}
 
-				// Combine discovered expressions into a single expression with AND
+				// Combine discovered expressions into a single expression with OR
 				if len(discoverdLicense) > 0 {
-					combinedExpression := strings.Join(discoverdLicense, " AND ")
+					combinedExpression := strings.Join(discoverdLicense, licenseExpJoinBy)
 
 					if !addedLicenses[combinedExpression] {
 						if targetComp.Evidence == nil {

--- a/pkg/enrich/enrich.go
+++ b/pkg/enrich/enrich.go
@@ -176,18 +176,8 @@ func Enricher(ctx context.Context, sbomDoc sbom.SBOMDocument, components []inter
 
 				// Combine discovered expressions into a single expression with OR
 				if len(discoverdLicense) > 0 {
-					combinedExpression := strings.Join(discoverdLicense, licenseExpJoinBy)
-
-					if !addedLicenses[combinedExpression] {
-						if targetComp.Evidence == nil {
-							targetComp.Evidence = &cydx.Evidence{
-								Licenses: &cydx.Licenses{},
-							}
-						}
-						*targetComp.Evidence.Licenses = append(*targetComp.Evidence.Licenses, cydx.LicenseChoice{Expression: combinedExpression})
-						addedLicenses[combinedExpression] = true
-						log.Debugf("Added discovered expression %s for %s@%s under Evidence.Licenses section\n", combinedExpression, c.Name, c.Version)
-					}
+					// TODO: Next follow up
+					// Addd discovered license as Evidence
 				}
 
 			} else {

--- a/pkg/enrich/extract/extract.go
+++ b/pkg/enrich/extract/extract.go
@@ -77,10 +77,6 @@ func Components(ctx context.Context, sbomDoc sbom.SBOMDocument, params *Params) 
 		return nil, totalComponents, totalSelectedComponents, fmt.Errorf("unsupported SBOM format")
 	}
 
-	if len(selectedComponents) == 0 {
-		return nil, totalComponents, totalSelectedComponents, fmt.Errorf("no components matched the selection criteria")
-	}
-
 	fmt.Printf("\nTotal Components: %d\t Selected For Enrichment: %d\n", totalComponents, totalSelectedComponents)
 
 	log.Debugf("extracted %d components out of %d for enrichment", totalSelectedComponents, totalComponents)

--- a/pkg/enrich/extract/extract.go
+++ b/pkg/enrich/extract/extract.go
@@ -34,7 +34,7 @@ type Params struct {
 }
 
 // Components selects components requiring license enrichment
-func Components(ctx context.Context, sbomDoc sbom.SBOMDocument, params *Params) ([]interface{}, error) {
+func Components(ctx context.Context, sbomDoc sbom.SBOMDocument, params *Params) ([]interface{}, int, int, error) {
 	log := logger.FromContext(ctx)
 	log.Debugf("extracting components for enrichment")
 
@@ -74,17 +74,18 @@ func Components(ctx context.Context, sbomDoc sbom.SBOMDocument, params *Params) 
 		}
 
 	default:
-		return nil, fmt.Errorf("unsupported SBOM format")
+		return nil, totalComponents, totalSelectedComponents, fmt.Errorf("unsupported SBOM format")
 	}
 
 	if len(selectedComponents) == 0 {
-		return nil, fmt.Errorf("no components matched the selection criteria")
+		return nil, totalComponents, totalSelectedComponents, fmt.Errorf("no components matched the selection criteria")
 	}
 
-	fmt.Printf("\nTotal Components: %d\t Selected For Enrichment: %d\n\n", totalComponents, totalSelectedComponents)
+	fmt.Printf("\nTotal Components: %d\t Selected For Enrichment: %d\n", totalComponents, totalSelectedComponents)
 
-	log.Debugf("extracted %d components out of %d for enrichment", len(selectedComponents), totalComponents)
-	return selectedComponents, nil
+	log.Debugf("extracted %d components out of %d for enrichment", totalSelectedComponents, totalComponents)
+
+	return selectedComponents, totalComponents, totalSelectedComponents, nil
 }
 
 // shouldSelectSPDXComponent checks if an SPDX package needs license enrichment

--- a/pkg/enrich/types.go
+++ b/pkg/enrich/types.go
@@ -24,19 +24,27 @@ import (
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 )
 
+var supportedLicenseExpressions = map[string]bool{
+	"OR":   true,
+	"AND":  true,
+	"WITH": true,
+	"+":    true,
+}
+
 type Target struct {
 	Component sbom.GetComponent
 	Field     string
 }
 
 type Config struct {
-	Fields     []string
-	Output     string
-	SBOMFile   string
-	Force      bool
-	Debug      bool
-	MaxRetries int
-	MaxWait    time.Duration
+	Fields                  []string
+	Output                  string
+	SBOMFile                string
+	Force                   bool
+	Debug                   bool
+	MaxRetries              int
+	MaxWait                 time.Duration
+	LicenseExpressionJoinBy string
 }
 
 type EnrichSummary struct {
@@ -78,6 +86,10 @@ func (p *Config) Validate() error {
 		if !SupportedEnrichFields[strings.ToLower(field)] {
 			return fmt.Errorf("unsupported field: %s (supported: %v)", field, SupportedEnrichFields)
 		}
+	}
+
+	if !supportedLicenseExpressions[p.LicenseExpressionJoinBy] {
+		return fmt.Errorf("unsupported license expression: %s (only supports: %v)", p.LicenseExpressionJoinBy, supportedLicenseExpressions)
 	}
 
 	return nil

--- a/pkg/enrich/types.go
+++ b/pkg/enrich/types.go
@@ -40,11 +40,25 @@ type Config struct {
 }
 
 type EnrichSummary struct {
-	Enriched       int
-	Skipped        int
-	Failed         int
-	Errors         []error
-	SkippedReasons map[string]string
+	TotalComponents    int
+	SelectedComponents int
+	Enriched           int
+	Skipped            int
+	Failed             int
+	Errors             []error
+	SkippedReasons     map[string]string
+}
+
+func NewEnrichSummary() *EnrichSummary {
+	return &EnrichSummary{
+		TotalComponents:    0,
+		SelectedComponents: 0,
+		Enriched:           0,
+		Skipped:            0,
+		SkippedReasons:     make(map[string]string),
+		Failed:             0,
+		Errors:             nil,
+	}
 }
 
 // SupportedEnrichFields defines the valid fields for enrichment.


### PR DESCRIPTION
This PR updates the following changes:
- update summary to include total, selected comps
- support `license-exp-join` flag for joining the license expression
- cleanup discovered license and evidence stuffs
- skip enrichment for invalid licenses too, such NOASSERTION, OTHER
