### PR TITLE
change sbom writing intendation to 2 space

### DIFF
--- a/pkg/sbom/write.go
+++ b/pkg/sbom/write.go
@@ -33,7 +33,7 @@ func WriteSBOM(w io.Writer, doc SBOMDocument) error {
 		return encoder.Encode(d)
 
 	case *spdx.Document:
-		output, err := json.MarshalIndent(d, "", "    ")
+		output, err := json.MarshalIndent(d, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal SPDX document: %w", err)
 		}


### PR DESCRIPTION
This PR adds the following changes:
- updates the intendation  from 4 space to 2 space.
- Due to which earlier, the whole SBOM structure get's changed, as a result on seeing the diff b/w old and enriched file shows lot's of difference, whereas in reality it should show only those fields which are enriched. And it works via 2 space.