### PR TITLE
validate type and show error on invalid input params

### DIFF
--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -25,6 +25,22 @@ import (
 	"github.com/samber/lo"
 )
 
+var supportedCDXComponentTypes map[string]bool = map[string]bool{
+	"application":            true,
+	"framework":              true,
+	"library":                true,
+	"container":              true,
+	"platform":               true,
+	"operating-system":       true,
+	"device":                 true,
+	"device-driver":          true,
+	"firmware":               true,
+	"file":                   true,
+	"machine-learning-model": true,
+	"data":                   true,
+	"cryptographic-asset":    true,
+}
+
 type cdxEditDoc struct {
 	bom  *cydx.BOM
 	comp *cydx.Component
@@ -84,6 +100,9 @@ func (d *cdxEditDoc) update() {
 			if err == errNotSupported {
 				log.Infof(fmt.Sprintf("CDX error updating %s: %s", item.name, err))
 			}
+			if err == errInvalidInput {
+				log.Infof(fmt.Sprintf("%s: %s", item.name, err))
+			}
 		}
 	}
 }
@@ -136,16 +155,22 @@ func (d *cdxEditDoc) typ() error {
 		return errNoConfiguration
 	}
 
+	newType := strings.ToLower(d.c.typ)
+
+	if !supportedCDXComponentTypes[newType] {
+		return errInvalidInput
+	}
+
 	if d.c.search.subject == "document" {
 		return errNotSupported
 	}
 
 	if d.c.onMissing() {
 		if d.comp.Type == "" {
-			d.comp.Type = cydx.ComponentType(d.c.typ)
+			d.comp.Type = cydx.ComponentType(newType)
 		}
 	} else {
-		d.comp.Type = cydx.ComponentType(d.c.typ)
+		d.comp.Type = cydx.ComponentType(newType)
 	}
 
 	return nil

--- a/pkg/edit/config.go
+++ b/pkg/edit/config.go
@@ -144,7 +144,6 @@ func (c *configParams) shouldSearch() bool {
 }
 
 func (c *configParams) getFormattedAuthors() string {
-
 	authors := []string{}
 	for _, author := range c.authors {
 		authors = append(authors, fmt.Sprintf("%s <%s>", author.name, author.value))
@@ -156,7 +155,7 @@ func (c *configParams) getFormattedAuthors() string {
 func convertToConfigParams(eParams *EditParams) (*configParams, error) {
 	p := &configParams{}
 
-	//log := logger.FromContext(*eParams.Ctx)
+	// log := logger.FromContext(*eParams.Ctx)
 
 	p.ctx = eParams.Ctx
 
@@ -253,6 +252,7 @@ func convertToConfigParams(eParams *EditParams) (*configParams, error) {
 
 	return p, nil
 }
+
 func parseInputFormat(s string) (name string, version string) {
 	// Trim any leading/trailing whitespace
 	s = strings.TrimSpace(s)
@@ -272,9 +272,9 @@ func parseInputFormat(s string) (name string, version string) {
 
 	return name, version
 }
+
 func validatePath(path string) error {
 	stat, err := os.Stat(path)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -98,6 +98,10 @@ func (d *spdxEditDoc) update() {
 			if err == errNotSupported {
 				log.Infof(fmt.Sprintf("SPDX error updating %s: %s", item.name, err))
 			}
+
+			if err == errInvalidInput {
+				log.Infof(fmt.Sprintf("%s: %s", item.name, err))
+			}
 		}
 	}
 }


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomasm/issues/211

This PR adds the following changes:
- it validates the CDX component type and shows an error for invalid input params.
