### PR TITLE
allow authors for pc and component as well

### DIFF
--- a/pkg/edit/spdx_edit.go
+++ b/pkg/edit/spdx_edit.go
@@ -190,10 +190,6 @@ func (d *spdxEditDoc) authors() error {
 		return errNoConfiguration
 	}
 
-	if d.c.search.subject != "document" {
-		return errNotSupported
-	}
-
 	authors := []spdx.Creator{}
 
 	for _, author := range d.c.authors {


### PR DESCRIPTION
closes: https://github.com/interlynk-io/sbomasm/issues/209

This PR adds the following changes:
- It allows addition of authors for primary component as well component along with document.