### PR TITLE
fix debug message for valid purl with no cd data

### DIFF
--- a/samples/test/enrich/dropwizard-missing-all-license.cdx.json
+++ b/samples/test/enrich/dropwizard-missing-all-license.cdx.json
@@ -24,12 +24,13 @@
   },
   "components" : [
     {
-      "group" : "io.dropwizard",
-      "name" : "dropwizard-json-logging",
-      "version" : "2.0.31",
-      "purl" : "pkg:maven/io.dropwizard/dropwizard-json-logging@2.0.31?type=jar",
+      "group" : "apple",
+      "name" : "swift-protobuf",
+      "version" : "1.31.1",
+      "purl" : "pkg:swift/github.com/apple/swift-protobuf@1.31.1",
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.dropwizard/dropwizard-json-logging@2.0.31?type=jar"
+      "description": "valid purl with no data present in clearlydefined as swift package not supported",
+      "bom-ref" : "pkg:swift/github.com/apple/swift-protobuf@1.31.1"
     },
     {
       "group" : "io.dropwizard.archetypes",


### PR DESCRIPTION
closes #236 

This PR adds the following changes:
- updates debug message.
- and differentiate b/w errors b/w invalid purls and valid purls with no data.
- also included this case into example

```bash
$ go run main.go enrich --fields="license" samples/test/enrich/dropwizard-missing-all-license.cdx.json    --output enriched-missing-license1.cdx.json -d

ordinate: maven/mavencentral/io.dropwizard/dropwizard-core/2.0.31
2025-10-07T17:31:17.784+0530	DEBUG	clearlydef/mapper.go:105	Missing PURLs: 0	 Invalid PURLs: 0	 Valid PURLs: 12	 Valid PURLs with no CD Data: 1

```