### PR TITLE
fix null pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/shiftleftcyber/securesbom-sdk-golang/v2 v2.3.0
 	github.com/spdx/tools-golang v0.5.7
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -28,12 +29,15 @@ require golang.org/x/mod v0.34.0 // indirect
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.21 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/tools v0.42.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/pkg/rm/cmps/handlers.go
+++ b/pkg/rm/cmps/handlers.go
@@ -185,6 +185,11 @@ func FindAllDependenciesForComponents(ctx context.Context, doc sbom.SBOMDocument
 			}
 		}
 
+		if sbomDoc.Dependencies == nil {
+			log.Debugf("No dependencies found in CycloneDX BOM")
+			return dependencies
+		}
+
 		for _, dep := range *sbomDoc.Dependencies {
 			totalDependencies++
 			if compRefs[dep.Ref] {


### PR DESCRIPTION
This PR fix the following issue:
- Throws an nil reference on empty dependency list
- It happens when no dependnecy list is absent.

For example:
To reproduce an issue:
```bash
sbomasm rm --components --field type --value "library" -o sbom4.json samples/cdx/sbomqs-cdx.json

{"level":"info","ts":1778080418.4836566,"caller":"cmps/handlers.go:249","msg":"Total components: 210, Total selected components: 209"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x93306b]

goroutine 1 [running]:
github.com/interlynk-io/sbomasm/v2/pkg/rm/cmps.FindAllDependenciesForComponents({0xe66a68?, 0xc000183c50?}, {0xe64a90, 0xc000268280}, {0xc0000aa008, 0xd1, 0x24?})
	github.com/interlynk-io/sbomasm/v2/pkg/rm/cmps/handlers.go:188 +0x3eb
github.com/interlynk-io/sbomasm/v2/pkg/rm.(*ComponentsOperationEngine).findDependenciesForComponents(...)
	github.com/interlynk-io/sbomasm/v2/pkg/rm/handlers.go:112
github.com/interlynk-io/sbomasm/v2/pkg/rm.(*ComponentsOperationEngine).Execute(0xc0003d7988, {0xe66a68, 0xc000183c50}, 0xc0002ad860)
	github.com/interlynk-io/sbomasm/v2/pkg/rm/execute.go:191 +0x125
github.com/interlynk-io/sbomasm/v2/pkg/rm.componentsRemoval({0xe66a68, 0xc000183c50}, {0xe64a90, 0xc000268280}, 0xc0002ad860)
	github.com/interlynk-io/sbomasm/v2/pkg/rm/remove.go:88 +0x9c
github.com/interlynk-io/sbomasm/v2/pkg/rm.Remove({0xe66a68, 0xc000183c50}, {0xe64a90, 0xc000268280}, 0xc0002ad860)
	github.com/interlynk-io/sbomasm/v2/pkg/rm/remove.go:46 +0x16b
github.com/interlynk-io/sbomasm/v2/pkg/rm.Engine({0xe66a68, 0xc000183c50}, {0xc000097100, 0x1, 0xb0f6ff?}, 0xc0002ad860)
	github.com/interlynk-io/sbomasm/v2/pkg/rm/engine.go:90 +0x59f
github.com/interlynk-io/sbomasm/v2/cmd.init.func8(0x12da9a0, {0xc000097100, 0x1, 0x8})
	github.com/interlynk-io/sbomasm/v2/cmd/remove.go:90 +0x185
github.com/spf13/cobra.(*Command).execute(0x12da9a0, {0xc000097080, 0x8, 0x8})
	github.com/spf13/cobra@v1.10.2/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0x12dac80)
	github.com/spf13/cobra@v1.10.2/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.10.2/command.go:1071
github.com/interlynk-io/sbomasm/v2/cmd.Execute()
	github.com/interlynk-io/sbomasm/v2/cmd/root.go:37 +0x1a
main.main()
	github.com/interlynk-io/sbomasm/v2/main.go:21 +0xf

```

Now fixed:
```bash
go run main.go rm --components --field type --value "library" -o sbom4.json samples/cdx/sbomqs-cdx.json 

{"level":"info","ts":1778080439.4565892,"caller":"cmps/handlers.go:254","msg":"Total components: 210, Total selected components: 209"}
successfully removed...
updated SBOM written to file: sbom4.json%     
```
