### PR TITLE
[feat]add group and publisher fields support for removal

### DIFF
--- a/docs/remove.md
+++ b/docs/remove.md
@@ -44,8 +44,10 @@ Removes specific fields from the document metadata or from components.
 | `author`      | `originator`            | `authors`              |
 | `copyright`   | `copyrightText`         | `copyright`            |
 | `cpe`         | `externalRefs` (cpe23)  | `cpe`                  |
+| `group`       | *(not applicable)*      | `group`                |
 | `hash`        | `packageChecksums` / checksums | `hashes`  |
 | `license`     | `licenseDeclared`       | `licenses`             |
+| `publisher`   | *(not applicable)*      | `publisher`            |
 | `purl`        | `externalRefs` (purl)   | `purl`                 |
 | `repository`  | `externalRefs` (vcs)    | `externalReferences`   |
 | `supplier`    | `packageSupplier`       | `supplier`             |
@@ -414,9 +416,11 @@ echo "Published SBOM written to $OUTPUT_SBOM"
 | `author`      | ✓              | ✓               |
 | `copyright`   |                | ✓               |
 | `cpe`         |                | ✓               |
+| `group`       |                | ✓ (CDX only)    |
 | `hash`        |                | ✓               |
 | `license`     | ✓              | ✓               |
 | `lifecycle`   | ✓              |                 |
+| `publisher`   |                | ✓ (CDX only)    |
 | `purl`        |                | ✓               |
 | `repository`  | ✓ (CDX only)   | ✓               |
 | `supplier`    | ✓              | ✓               |

--- a/pkg/rm/cmps/handlers.go
+++ b/pkg/rm/cmps/handlers.go
@@ -854,6 +854,18 @@ func getCDXComponentFieldValue(ctx context.Context, comp cydx.Component, field s
 			log.Debugf("Found hash values for %s: %s", comp.BOMRef, strings.Join(values, ","))
 			return strings.Join(values, ",")
 		}
+
+	case "group":
+		if comp.Group != "" {
+			log.Debugf("Found group value for %s: %s", comp.BOMRef, comp.Group)
+			return comp.Group
+		}
+
+	case "publisher":
+		if comp.Publisher != "" {
+			log.Debugf("Found publisher value for %s: %s", comp.BOMRef, comp.Publisher)
+			return comp.Publisher
+		}
 	}
 	return ""
 }

--- a/pkg/rm/cmps/handlers.go
+++ b/pkg/rm/cmps/handlers.go
@@ -213,8 +213,6 @@ func FindAllDependenciesForComponents(ctx context.Context, doc sbom.SBOMDocument
 }
 
 func SelectComponents(ctx context.Context, sbomDoc sbom.SBOMDocument, params *types.RmParams) ([]interface{}, error) {
-	log := logger.FromContext(ctx)
-
 	var selectedComponents []interface{}
 	var totalComponents int
 	var totalSelectedComponents int
@@ -251,9 +249,7 @@ func SelectComponents(ctx context.Context, sbomDoc sbom.SBOMDocument, params *ty
 	if len(selectedComponents) == 0 {
 		return nil, fmt.Errorf("no components matched the selection criteria")
 	}
-	log.Infof("Total components: %d, Total selected components: %d", totalComponents, totalSelectedComponents)
 
-	// fmt.Println("Selected components:", selectedComponents)
 	return selectedComponents, nil
 }
 

--- a/pkg/rm/engine.go
+++ b/pkg/rm/engine.go
@@ -26,9 +26,12 @@ import (
 
 	cydx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/interlynk-io/sbomasm/v2/pkg/logger"
+	cdxcomp "github.com/interlynk-io/sbomasm/v2/pkg/rm/field/cdx"
+	spdxcomp "github.com/interlynk-io/sbomasm/v2/pkg/rm/field/spdx"
 	"github.com/interlynk-io/sbomasm/v2/pkg/rm/types"
 	"github.com/interlynk-io/sbomasm/v2/pkg/sbom"
 	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdx/v2/common"
 )
 
 func Engine(ctx context.Context, args []string, params *types.RmParams) error {
@@ -91,6 +94,12 @@ func Engine(ctx context.Context, args []string, params *types.RmParams) error {
 	if err != nil {
 		return err
 	}
+
+	// Skip writing output in dry-run mode
+	if params.DryRun {
+		return nil
+	}
+
 	fmt.Println("successfully removed...")
 
 	if params.OutputFile != "" {
@@ -157,9 +166,53 @@ func (f *FieldOperationEngine) ExecuteDocumentFieldRemoval(ctx context.Context, 
 		return nil
 	}
 	if params.DryRun {
-		log.Debugf("Dry-run: matched entries:")
+		fmt.Printf("Dry-run: matched entries:\n")
 		for _, entry := range targets {
-			fmt.Printf("  - %v\n", entry)
+			switch e := entry.(type) {
+			case common.Creator:
+				fmt.Printf("  - Creator: %s (%s)\n", e.Creator, e.CreatorType)
+			case spdx.Originator:
+				fmt.Printf("  - Author: %s (%s)\n", e.Originator, e.OriginatorType)
+			case spdx.Supplier:
+				fmt.Printf("  - Supplier: %s (%s)\n", e.Supplier, e.SupplierType)
+			case cydx.OrganizationalContact:
+				fmt.Printf("  - Author: %s (%s)\n", e.Name, e.Email)
+			case cydx.OrganizationalEntity:
+				fmt.Printf("  - Supplier: %s\n", e.Name)
+			case cydx.LicenseChoice:
+				if e.License != nil {
+					if e.License.ID != "" {
+						fmt.Printf("  - License: %s\n", e.License.ID)
+					} else if e.License.Name != "" {
+						fmt.Printf("  - License: %s\n", e.License.Name)
+					}
+				} else if e.Expression != "" {
+					fmt.Printf("  - License Expression: %s\n", e.Expression)
+				}
+			case cydx.Lifecycle:
+				fmt.Printf("  - Lifecycle: %s\n", e.Phase)
+			case cydx.Tool:
+				fmt.Printf("  - Tool: %s@%s\n", e.Name, e.Version)
+			case cydx.Component:
+				fmt.Printf("  - Tool: %s@%s\n", e.Name, e.Version)
+			case []cydx.Component:
+				for _, c := range e {
+					fmt.Printf("  - Tool: %s@%s\n", c.Name, c.Version)
+				}
+			case []cydx.Tool:
+				for _, t := range e {
+					fmt.Printf("  - Tool: %s@%s\n", t.Name, t.Version)
+				}
+			case []cydx.OrganizationalContact:
+				for _, a := range e {
+					fmt.Printf("  - Author: %s (%s)\n", a.Name, a.Email)
+				}
+			case string:
+				// timestamp, repository URL, etc.
+				fmt.Printf("  - %s\n", e)
+			default:
+				fmt.Printf("  - %v\n", entry)
+			}
 		}
 		return nil
 	}
@@ -180,8 +233,6 @@ func (f *FieldOperationEngine) ExecuteComponentFieldRemoval(ctx context.Context,
 		log.Debugf("No matching components found.")
 		return nil
 	}
-
-	log.Infof("Total selected components for field removal: %d", len(selectedComponents))
 
 	// Step 2: For each selected component, operate on field
 	spec, field := f.doc.SpecType(), strings.ToLower(params.Field)
@@ -221,9 +272,92 @@ func (f *FieldOperationEngine) ExecuteComponentFieldRemoval(ctx context.Context,
 		return nil
 	}
 	if params.DryRun {
-		log.Infof("Dry-run: matched field entries:")
+		fmt.Printf("Dry-run: matched field entries:\n")
 		for _, entry := range targets {
-			fmt.Printf("  - %v\n", entry)
+			switch e := entry.(type) {
+			case spdxcomp.AuthorEntry:
+				author := ""
+				if e.Originator != nil {
+					author = e.Originator.Originator
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, author)
+			case spdxcomp.SupplierEntry:
+				supplier := ""
+				if e.Supplier != nil {
+					supplier = e.Supplier.Supplier
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, supplier)
+			case spdxcomp.DescriptionEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, e.Value)
+			case spdxcomp.CopyrightEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, e.Value)
+			case spdxcomp.RepositoryEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, e.Value)
+			case spdxcomp.LicenseEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, e.Value)
+			case spdxcomp.TypeEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, e.Value)
+			case spdxcomp.CpeEntry:
+				cpe := ""
+				if e.Ref != nil {
+					cpe = e.Ref.Locator
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, cpe)
+			case spdxcomp.HashEntry:
+				hash := ""
+				if e.Checksum != nil {
+					hash = e.Checksum.Value
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, hash)
+			case spdxcomp.PurlEntry:
+				purl := ""
+				if e.Ref != nil {
+					purl = e.Ref.Locator
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Package.PackageName, e.Package.PackageVersion, purl)
+			case cdxcomp.AuthorEntry:
+				author := ""
+				if e.Author != nil {
+					author = fmt.Sprintf("%s (%s)", e.Author.Name, e.Author.Email)
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, author)
+			case cdxcomp.SupplierEntry:
+				supplier := ""
+				if e.Value != nil {
+					supplier = e.Value.Name
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, supplier)
+			case cdxcomp.DescriptionEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Value)
+			case cdxcomp.CopyrightEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Value)
+			case cdxcomp.RepositoryEntry:
+				url := ""
+				if e.Ref != nil {
+					url = e.Ref.URL
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, url)
+			case cdxcomp.LicenseEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Value)
+			case cdxcomp.TypeEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Value)
+			case cdxcomp.CpeEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Ref)
+			case cdxcomp.HashEntry:
+				hash := ""
+				if e.Hash != nil {
+					hash = e.Hash.Value
+				}
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, hash)
+			case cdxcomp.PurlEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Value)
+			case cdxcomp.GroupEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Value)
+			case cdxcomp.PublisherEntry:
+				fmt.Printf("  - %s@%s: %s\n", e.Component.Name, e.Component.Version, e.Value)
+			default:
+				fmt.Printf("  - %v\n", entry)
+			}
 		}
 		return nil
 	}

--- a/pkg/rm/execute.go
+++ b/pkg/rm/execute.go
@@ -181,6 +181,14 @@ func (c *ComponentsOperationEngine) Execute(ctx context.Context, params *types.R
 	log := logger.FromContext(ctx)
 	log.Debugf("Executing components removal process")
 
+	// Validate field if provided
+	if params.Field != "" {
+		spec := c.doc.SpecType()
+		if err := types.ValidateComponentField(spec, params.Field); err != nil {
+			return err
+		}
+	}
+
 	// Step 1: Select components based on filter criteria
 	selectedComponents, err := c.selectComponents(ctx, params)
 	if err != nil {

--- a/pkg/rm/execute.go
+++ b/pkg/rm/execute.go
@@ -201,6 +201,35 @@ func (c *ComponentsOperationEngine) Execute(ctx context.Context, params *types.R
 		return fmt.Errorf("error selecting dependencies: %w", err)
 	}
 
+	// Handle dry-run mode
+	if params.DryRun {
+		fmt.Printf("Dry-run: would remove %d component(s):\n", len(selectedComponents))
+		for _, comp := range selectedComponents {
+			switch c := comp.(type) {
+			case spdx.Package:
+				fmt.Printf("  - %s@%s\n", c.PackageName, c.PackageVersion)
+			case cydx.Component:
+				fmt.Printf("  - %s@%s\n", c.Name, c.Version)
+			default:
+				fmt.Printf("  - %v\n", comp)
+			}
+		}
+		if len(selectedDeps) > 0 {
+			fmt.Printf("Dry-run: would remove %d dependency reference(s):\n", len(selectedDeps))
+			for _, dep := range selectedDeps {
+				switch d := dep.(type) {
+				case string:
+					fmt.Printf("  - %s\n", d)
+				case cydx.Dependency:
+					fmt.Printf("  - %s\n", d.Ref)
+				default:
+					fmt.Printf("  - %v\n", dep)
+				}
+			}
+		}
+		return nil
+	}
+
 	// Step 3: Remove components
 	if err := c.removeComponents(ctx, selectedComponents); err != nil {
 		return fmt.Errorf("error removing components: %w", err)

--- a/pkg/rm/field/cdx/field.go
+++ b/pkg/rm/field/cdx/field.go
@@ -77,3 +77,15 @@ type PurlEntry struct {
 	Component *cydx.Component
 	Value     string // Use string for PURL to handle Component.PURL
 }
+
+// GroupEntry for Component.Group
+type GroupEntry struct {
+	Component *cydx.Component
+	Value     string
+}
+
+// PublisherEntry for Component.Publisher
+type PublisherEntry struct {
+	Component *cydx.Component
+	Value     string
+}

--- a/pkg/rm/field/cdx/filter.go
+++ b/pkg/rm/field/cdx/filter.go
@@ -653,3 +653,79 @@ func FilterTypeFromComponent(doc *cydx.BOM, selected []interface{}, params *type
 	log.Debugf("Filtered type from component: %v", filtered)
 	return filtered, nil
 }
+
+func FilterGroupFromComponent(doc *cydx.BOM, selected []interface{}, params *types.RmParams) ([]interface{}, error) {
+	log := logger.FromContext(*params.Ctx)
+	log.Debugf("Filtering group from component")
+
+	if params.Value == "" && !params.All && !params.IsKeyPresent {
+		return selected, nil
+	}
+
+	var filtered []interface{}
+	for _, e := range selected {
+		entry, ok := e.(GroupEntry)
+		if !ok || entry.Value == "" {
+			log.Warn("Skipping invalid group entry:", e)
+			continue
+		}
+
+		match := false
+		switch {
+		case params.IsFieldAndValuePresent:
+			if strings.EqualFold(entry.Value, params.Value) {
+				match = true
+			}
+			if params.Value == "NOASSERTION" {
+				log.Warn("Warning: NOASSERTION is unlikely for group field")
+			}
+		default:
+			match = true
+		}
+
+		if match {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	log.Debugf("Filtered group from component: %v", filtered)
+	return filtered, nil
+}
+
+func FilterPublisherFromComponent(doc *cydx.BOM, selected []interface{}, params *types.RmParams) ([]interface{}, error) {
+	log := logger.FromContext(*params.Ctx)
+	log.Debugf("Filtering publisher from component")
+
+	if params.Value == "" && !params.All && !params.IsKeyPresent {
+		return selected, nil
+	}
+
+	var filtered []interface{}
+	for _, e := range selected {
+		entry, ok := e.(PublisherEntry)
+		if !ok || entry.Value == "" {
+			log.Warn("Skipping invalid publisher entry:", e)
+			continue
+		}
+
+		match := false
+		switch {
+		case params.IsFieldAndValuePresent:
+			if strings.EqualFold(entry.Value, params.Value) {
+				match = true
+			}
+			if params.Value == "NOASSERTION" {
+				log.Warn("Warning: NOASSERTION is unlikely for publisher field")
+			}
+		default:
+			match = true
+		}
+
+		if match {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	log.Debugf("Filtered publisher from component: %v", filtered)
+	return filtered, nil
+}

--- a/pkg/rm/field/cdx/remove.go
+++ b/pkg/rm/field/cdx/remove.go
@@ -821,3 +821,91 @@ func RemoveTypeFromComponent(doc *cydx.BOM, entries []interface{}, params *types
 	}
 	return nil
 }
+
+func RemoveGroupFromComponent(doc *cydx.BOM, entries []interface{}, params *types.RmParams) error {
+	log := logger.FromContext(*params.Ctx)
+	removedCount := 0
+	for _, e := range entries {
+		entry, ok := e.(GroupEntry)
+		if !ok || entry.Value == "" {
+			log.Debugf("Skipping invalid group entry: %v", e)
+			continue
+		}
+
+		comp := entry.Component
+		found := false
+		if doc.Metadata.Component != nil && comp == doc.Metadata.Component {
+			found = true
+		} else if doc.Components != nil {
+			for i := range *doc.Components {
+				if &(*doc.Components)[i] == comp {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			log.Warnf("Warning: Component %s@%s not found in document\n", comp.Name, comp.Version)
+			continue
+		}
+
+		if strings.EqualFold(comp.Group, entry.Value) {
+			comp.Group = ""
+			removedCount++
+			log.Debugf("Removed group from component: %s@%s, Group: %s\n", comp.Name, comp.Version, entry.Value)
+			if params.Value == "NOASSERTION" {
+				log.Warnf("Matched NOASSERTION for group")
+			}
+		}
+	}
+
+	log.Debugf("Removed %d group entries from components\n", removedCount)
+	if len(entries) > 0 && removedCount == 0 {
+		log.Debugf("No group entries removed\n")
+	}
+	return nil
+}
+
+func RemovePublisherFromComponent(doc *cydx.BOM, entries []interface{}, params *types.RmParams) error {
+	log := logger.FromContext(*params.Ctx)
+	removedCount := 0
+	for _, e := range entries {
+		entry, ok := e.(PublisherEntry)
+		if !ok || entry.Value == "" {
+			log.Debugf("Skipping invalid publisher entry: %v", e)
+			continue
+		}
+
+		comp := entry.Component
+		found := false
+		if doc.Metadata.Component != nil && comp == doc.Metadata.Component {
+			found = true
+		} else if doc.Components != nil {
+			for i := range *doc.Components {
+				if &(*doc.Components)[i] == comp {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			log.Warnf("Warning: Component %s@%s not found in document\n", comp.Name, comp.Version)
+			continue
+		}
+
+		if strings.EqualFold(comp.Publisher, entry.Value) {
+			comp.Publisher = ""
+			removedCount++
+			log.Debugf("Removed publisher from component: %s@%s, Publisher: %s\n", comp.Name, comp.Version, entry.Value)
+			if params.Value == "NOASSERTION" {
+				log.Warnf("Matched NOASSERTION for publisher")
+			}
+		}
+	}
+
+	log.Debugf("Removed %d publisher entries from components\n", removedCount)
+	if len(entries) > 0 && removedCount == 0 {
+		log.Debugf("No publisher entries removed\n")
+	}
+	return nil
+}

--- a/pkg/rm/field/cdx/select.go
+++ b/pkg/rm/field/cdx/select.go
@@ -372,3 +372,47 @@ func SelectTypeFromComponent(doc *cydx.BOM, params *types.RmParams) ([]interface
 	log.Debugf("Selected types from component: %v", selected)
 	return selected, nil
 }
+
+func SelectGroupFromComponent(doc *cydx.BOM, params *types.RmParams) ([]interface{}, error) {
+	log := logger.FromContext(*params.Ctx)
+	log.Debugf("Selecting group from component")
+
+	var selected []interface{}
+	for _, comp := range params.SelectedComponents {
+		c, ok := comp.(*cydx.Component)
+		if !ok {
+			continue
+		}
+		if c.Group != "" {
+			log.Debugf("Selecting group from component: %s@%s, Group: %s", c.Name, c.Version, c.Group)
+			selected = append(selected, GroupEntry{Component: c, Value: c.Group})
+		}
+	}
+	if len(selected) == 0 {
+		log.Debugf("No group entries found in selected components")
+	}
+	log.Debugf("Selected groups from component: %v", selected)
+	return selected, nil
+}
+
+func SelectPublisherFromComponent(doc *cydx.BOM, params *types.RmParams) ([]interface{}, error) {
+	log := logger.FromContext(*params.Ctx)
+	log.Debugf("Selecting publisher from component")
+
+	var selected []interface{}
+	for _, comp := range params.SelectedComponents {
+		c, ok := comp.(*cydx.Component)
+		if !ok {
+			continue
+		}
+		if c.Publisher != "" {
+			log.Debugf("Selecting publisher from component: %s@%s, Publisher: %s", c.Name, c.Version, c.Publisher)
+			selected = append(selected, PublisherEntry{Component: c, Value: c.Publisher})
+		}
+	}
+	if len(selected) == 0 {
+		log.Debugf("No publisher entries found in selected components")
+	}
+	log.Debugf("Selected publishers from component: %v", selected)
+	return selected, nil
+}

--- a/pkg/rm/field/cdx/summary.go
+++ b/pkg/rm/field/cdx/summary.go
@@ -342,3 +342,43 @@ func RenderSummaryTypeFromComponent(entries []interface{}) {
 			entry.Value)
 	}
 }
+
+func RenderSummaryGroupFromComponent(entries []interface{}) {
+	fmt.Println("Summary of group entries to be removed:")
+	if len(entries) == 0 {
+		fmt.Println("No group entries selected for removal")
+		return
+	}
+
+	for _, e := range entries {
+		entry, ok := e.(GroupEntry)
+		if !ok || entry.Value == "" {
+			fmt.Println("Skipping invalid group entry:", e)
+			continue
+		}
+		fmt.Printf("  - Component: %s@%s, Group: %s\n",
+			entry.Component.Name,
+			entry.Component.Version,
+			entry.Value)
+	}
+}
+
+func RenderSummaryPublisherFromComponent(entries []interface{}) {
+	fmt.Println("Summary of publisher entries to be removed:")
+	if len(entries) == 0 {
+		fmt.Println("No publisher entries selected for removal")
+		return
+	}
+
+	for _, e := range entries {
+		entry, ok := e.(PublisherEntry)
+		if !ok || entry.Value == "" {
+			fmt.Println("Skipping invalid publisher entry:", e)
+			continue
+		}
+		fmt.Printf("  - Component: %s@%s, Publisher: %s\n",
+			entry.Component.Name,
+			entry.Component.Version,
+			entry.Value)
+	}
+}

--- a/pkg/rm/field/handler/cdx/comp/group.go
+++ b/pkg/rm/field/handler/cdx/comp/group.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Interlynk.io
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package comp
+
+import (
+	cydx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/interlynk-io/sbomasm/v2/pkg/rm/field/cdx"
+	"github.com/interlynk-io/sbomasm/v2/pkg/rm/types"
+)
+
+type CdxComponentGroupHandler struct {
+	Bom *cydx.BOM
+}
+
+func (h *CdxComponentGroupHandler) Select(params *types.RmParams) ([]interface{}, error) {
+	return cdx.SelectGroupFromComponent(h.Bom, params)
+}
+
+func (h *CdxComponentGroupHandler) Filter(selected []interface{}, params *types.RmParams) ([]interface{}, error) {
+	return cdx.FilterGroupFromComponent(h.Bom, selected, params)
+}
+
+func (h *CdxComponentGroupHandler) Remove(targets []interface{}, params *types.RmParams) error {
+	return cdx.RemoveGroupFromComponent(h.Bom, targets, params)
+}
+
+func (h *CdxComponentGroupHandler) Summary(selected []interface{}) {
+	cdx.RenderSummaryGroupFromComponent(selected)
+}

--- a/pkg/rm/field/handler/cdx/comp/group.go
+++ b/pkg/rm/field/handler/cdx/comp/group.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Interlynk.io
+// Copyright 2026 Interlynk.io
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rm/field/handler/cdx/comp/publisher.go
+++ b/pkg/rm/field/handler/cdx/comp/publisher.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Interlynk.io
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package comp
+
+import (
+	cydx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/interlynk-io/sbomasm/v2/pkg/rm/field/cdx"
+	"github.com/interlynk-io/sbomasm/v2/pkg/rm/types"
+)
+
+type CdxComponentPublisherHandler struct {
+	Bom *cydx.BOM
+}
+
+func (h *CdxComponentPublisherHandler) Select(params *types.RmParams) ([]interface{}, error) {
+	return cdx.SelectPublisherFromComponent(h.Bom, params)
+}
+
+func (h *CdxComponentPublisherHandler) Filter(selected []interface{}, params *types.RmParams) ([]interface{}, error) {
+	return cdx.FilterPublisherFromComponent(h.Bom, selected, params)
+}
+
+func (h *CdxComponentPublisherHandler) Remove(targets []interface{}, params *types.RmParams) error {
+	return cdx.RemovePublisherFromComponent(h.Bom, targets, params)
+}
+
+func (h *CdxComponentPublisherHandler) Summary(selected []interface{}) {
+	cdx.RenderSummaryPublisherFromComponent(selected)
+}

--- a/pkg/rm/field/handler/cdx/comp/publisher.go
+++ b/pkg/rm/field/handler/cdx/comp/publisher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Interlynk.io
+// Copyright 2026 Interlynk.io
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/rm/handlers.go
+++ b/pkg/rm/handlers.go
@@ -56,6 +56,8 @@ func RegisterHandlers(bom *cydx.BOM, spdxDoc *spdxdoc.Document) {
 	handlerRegistry["cdx:component:cpe"] = &cdxcomp.CdxComponentCpeHandler{Bom: bom}
 	handlerRegistry["cdx:component:purl"] = &cdxcomp.CdxComponentPurlHandler{Bom: bom}
 	handlerRegistry["cdx:component:hash"] = &cdxcomp.CdxComponentHashHandler{Bom: bom}
+	handlerRegistry["cdx:component:group"] = &cdxcomp.CdxComponentGroupHandler{Bom: bom}
+	handlerRegistry["cdx:component:publisher"] = &cdxcomp.CdxComponentPublisherHandler{Bom: bom}
 
 	// SPDX Document-level handlers
 	handlerRegistry["spdx:document:author"] = &spdxmeta.SpdxDocAuthorHandler{Doc: spdxDoc}

--- a/pkg/rm/types/validate.go
+++ b/pkg/rm/types/validate.go
@@ -16,7 +16,10 @@
 
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 var ValidFields = map[string][]string{
 	"document": {
@@ -158,4 +161,43 @@ func contains(allowedFields []string, field string) bool {
 		}
 	}
 	return false
+}
+
+// ValidateComponentField validates if the field is supported for component removal
+// based on the SBOM spec type (spdx or cdx)
+func ValidateComponentField(spec, field string) error {
+	field = strings.ToLower(field)
+	spec = strings.ToLower(spec)
+
+	// Common fields supported by both SPDX and CDX
+	commonFields := []string{"author", "supplier", "type", "repository", "cpe",
+		"hash", "license", "copyright", "purl", "description"}
+
+	// CDX-specific fields
+	cdxFields := []string{"group", "publisher"}
+
+	// Check if it's a common field
+	for _, f := range commonFields {
+		if f == field {
+			return nil
+		}
+	}
+
+	// For CDX, also check CDX-specific fields
+	if spec == "cdx" {
+		for _, f := range cdxFields {
+			if f == field {
+				return nil
+			}
+		}
+	}
+
+	// Build allowed fields list based on spec
+	var allowedFields []string
+	allowedFields = append(allowedFields, commonFields...)
+	if spec == "cdx" {
+		allowedFields = append(allowedFields, cdxFields...)
+	}
+
+	return fmt.Errorf("invalid field '%s' for spec '%s'. Allowed values are: %v", field, spec, allowedFields)
 }

--- a/pkg/rm/types/validate.go
+++ b/pkg/rm/types/validate.go
@@ -40,6 +40,8 @@ var ValidFields = map[string][]string{
 		"copyright",
 		"purl",
 		"description",
+		"group",
+		"publisher",
 	},
 	"dependency": {
 		"from",

--- a/samples/test/remove/README.md
+++ b/samples/test/remove/README.md
@@ -318,6 +318,12 @@ sbomasm rm --components --field supplier  samples/test/remove/complete-sbom.cdx.
 sbomasm rm --components --field type  samples/test/remove/complete-sbom.spdx.json -o remove-comp-with-type-field.sbom.spdx.json
 
 sbomasm rm --components --field type  samples/test/remove/complete-sbom.cdx.json -o remove-comp-with-type-field.sbom.cdx.json
+
+# group (CDX only)
+sbomasm rm --components --field group  samples/test/remove/complete-sbom.cdx.json -o remove-all-components-with-group.cdx.json
+
+# publisher (CDX only)
+sbomasm rm --components --field publisher  samples/test/remove/complete-sbom.cdx.json -o remove-all-components-with-publisher.cdx.json
 ```
 
 ### 4.2 Remove all component if field and value is present
@@ -382,4 +388,10 @@ sbomasm rm --components --field supplier --value "Sigstore"  samples/test/remove
 sbomasm rm --components --field type --value "library"  samples/test/remove/complete-sbom.spdx.json -o remove-comp-with-type-field-with-value.sbom.spdx.json
 
 sbomasm rm --components --field type --value "library"  samples/test/remove/complete-sbom.cdx.json -o remove-comp-with-type-field-with-value.sbom.cdx.json
+
+# group (CDX only)
+sbomasm rm --components --field group --value "github.com/fluxcd"  samples/test/remove/complete-sbom.cdx.json -o remove-fluxcd-group-components.cdx.json
+
+# publisher (CDX only)
+sbomasm rm --components --field publisher --value "cel.dev"  samples/test/remove/complete-sbom.cdx.json -o remove-cel.dev-group-components.cdx.json
 ```

--- a/samples/test/remove/complete-sbom.cdx.json
+++ b/samples/test/remove/complete-sbom.cdx.json
@@ -79,6 +79,8 @@
     ],
     "component": {
         "bom-ref": "pkg:golang/github.com/kyverno/kyverno@v1.14.0?type=module#cmd/kyverno",
+        "group": "github.com/kyverno",
+        "publisher": "kyverno.io",
         "type": "application",
         "name": "github.com/kyverno/kyverno",
         "version": "v1.14.0",
@@ -133,6 +135,8 @@
     {
       "bom-ref": "pkg:golang/github.com/fluxcd/pkg/oci@v0.45.0?type=module",
       "type": "library",
+      "group": "github.com/fluxcd",
+      "publisher": "fluxcd.io",
       "name": "github.com/fluxcd/pkg/oci",
       "version": "v0.45.0",
       "licenses": [
@@ -185,6 +189,8 @@
     {
       "bom-ref": "pkg:golang/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.17.0?type=module",
       "type": "library",
+      "group": "github.com/Azure",
+      "publisher": "azure.microsoft.com",
       "name": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
       "version": "v1.17.0",
       "licenses": [
@@ -237,6 +243,8 @@
     {
       "bom-ref": "pkg:golang/github.com/sigstore/rekor@v1.3.9?type=module",
       "type": "library",
+      "group": "github.com/sigstore",
+      "publisher": "sigstore.dev",
       "name": "github.com/sigstore/rekor",
       "version": "v1.3.9",
       "licenses": [
@@ -289,6 +297,8 @@
     {
       "bom-ref": "pkg:golang/cel.dev/expr@v0.19.1?type=module",
       "type": "library",
+      "group":"cel.dev",
+      "publisher": "cel.dev",
       "name": "cel.dev/expr",
       "version": "v0.19.1",
       "licenses": [


### PR DESCRIPTION
closes #296 
THis PR adds the following changes:
- Add support for 2 new fields in removal : `group` and `publisher` for cdx only.
- Also fixed `--dry-run` for various fields.
- Fixed o/p with proper list of supported fields

Demo Part:
```bash
// it removes all components and it's linked dependencies, as all the components have the field "group"
$ go run main.go rm --components --field group samples/test/remove/complete-sbom.cdx.json -o remove-all-components-with-group.cdx.json

// it removes component fluxcd, which contains field "group" with value "github.com/fluxcd", and respective graph deps
$ go run main.go rm --components --field group --value "github.com/fluxcd" samples/test/remove/complete-sbom.cdx.json -o remove-fluxcd-group-components.cdx.json

// it removes all components and it's linked dependencies, as all the components have the field "publisher"
$ go run main.go rm --components --field publisher samples/test/remove/complete-sbom.cdx.json -o remove-all-components-with-publisher.cdx.json

// it removes component ce..dev, which contains field "publisher" with value "cel.dev", and respective graph deps
$ go run main.go rm --components --field publisher --value "cel.dev" samples/test/remove/complete-sbom.cdx.json -o remove-cel.dev-group-components.cdx.json
```

- when wrong field is provided, then prints proper list of supported fields, earlier it wasn't
```bash
// when wrong field is provided, then prints proper list of supported fields, earlier it wasn't
$ go run main.go rm --components --field grouwp --value "github.com/fluxcd" samples/test/remove/complete-sbom.cdx.json -o remove-fluxcd-group-components.cdx.json 
Error: invalid field 'grouwp' for spec 'cdx'. Allowed values are: [author supplier type repository cpe hash license copyright purl description group publisher]
exit status 1
```
- on `--dry-run` it shows proper list of components and dependencies being removed.
```bash
 $ go run main.go rm --components --field author  samples/test/remove/complete-sbom.cdx.json --dry-run 
Dry-run: would remove 5 component(s):
  - github.com/fluxcd/pkg/oci@v0.45.0
  - github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.17.0
  - github.com/sigstore/rekor@v1.3.9
  - cel.dev/expr@v0.19.1
  - github.com/kyverno/kyverno@v1.14.0
Dry-run: would remove 3 dependency reference(s):
  - pkg:golang/github.com/kyverno/kyverno@v1.14.0?type=module#cmd/kyverno
  - pkg:golang/github.com/fluxcd/pkg/oci@v0.45.0?type=module
  - pkg:golang/github.com/sigstore/rekor@v1.3.9?type=module
```