### PR TITLE
Fix/metadata nil issue

### DIFF
--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -64,7 +64,7 @@ func NewCdxEditDoc(b *cydx.BOM, c *configParams) (*cdxEditDoc, error) {
 	doc.c = c
 
 	if c.search.subject == "primary-component" {
-		if b.Metadata.Component == nil {
+		if b.Metadata == nil || b.Metadata.Component == nil {
 			return nil, fmt.Errorf("primary component is missing")
 		}
 		doc.comp = b.Metadata.Component
@@ -78,6 +78,12 @@ func NewCdxEditDoc(b *cydx.BOM, c *configParams) (*cdxEditDoc, error) {
 	}
 
 	return doc, nil
+}
+
+func (d *cdxEditDoc) ensureMetadata() {
+	if d.bom.Metadata == nil {
+		d.bom.Metadata = &cydx.Metadata{}
+	}
 }
 
 func (d *cdxEditDoc) update() {
@@ -118,10 +124,11 @@ func (d *cdxEditDoc) update() {
 }
 
 func (d *cdxEditDoc) timeStamp() error {
-	if d.c.shouldTimeStamp() {
+	if !d.c.shouldTimeStamp() {
 		return errNoConfiguration
 	}
 
+	d.ensureMetadata()
 	d.bom.Metadata.Timestamp = utcNowTime()
 	return nil
 }
@@ -149,6 +156,7 @@ func (d *cdxEditDoc) lifeCycles() error {
 		})
 	}
 
+	d.ensureMetadata()
 	if d.c.onMissing() {
 		if d.bom.Metadata.Lifecycles == nil {
 			d.bom.Metadata.Lifecycles = &lc
@@ -370,6 +378,10 @@ func (d *cdxEditDoc) tools() error {
 }
 
 func (d *cdxEditDoc) initializeMetadataTools() {
+	if d.bom.Metadata == nil {
+		d.bom.Metadata = &cydx.Metadata{}
+	}
+
 	if d.bom.SpecVersion > cydx.SpecVersion1_4 {
 		if d.bom.Metadata.Tools == nil {
 			d.bom.Metadata.Tools = &cydx.ToolsChoice{
@@ -584,6 +596,8 @@ func (d *cdxEditDoc) licenses() error {
 		return errNoConfiguration
 	}
 
+	d.ensureMetadata()
+
 	lics := cdxConstructLicenses(d.bom, d.c)
 
 	if d.c.onMissing() {
@@ -700,6 +714,8 @@ func (d *cdxEditDoc) supplier() error {
 		return errNoConfiguration
 	}
 
+	d.ensureMetadata()
+
 	supplier := cdxConstructSupplier(d.bom, d.c)
 
 	if d.c.onMissing() {
@@ -727,6 +743,8 @@ func (d *cdxEditDoc) authors() error {
 	if !d.c.shouldAuthors() {
 		return errNoConfiguration
 	}
+
+	d.ensureMetadata()
 
 	authors := cdxConstructAuthors(d.bom, d.c)
 

--- a/pkg/rm/engine.go
+++ b/pkg/rm/engine.go
@@ -100,7 +100,11 @@ func Engine(ctx context.Context, args []string, params *types.RmParams) error {
 		return nil
 	}
 
-	fmt.Println("successfully removed...")
+	if params.RemovedCount > 0 {
+		fmt.Println("successfully removed...")
+	} else {
+		fmt.Println("no matching entries found.")
+	}
 
 	if params.OutputFile != "" {
 
@@ -217,6 +221,7 @@ func (f *FieldOperationEngine) ExecuteDocumentFieldRemoval(ctx context.Context, 
 		return nil
 	}
 
+	params.RemovedCount += len(targets)
 	return handler.Remove(targets, params)
 }
 
@@ -363,5 +368,6 @@ func (f *FieldOperationEngine) ExecuteComponentFieldRemoval(ctx context.Context,
 	}
 
 	// Step 5: Remove matched fields from components
+	params.RemovedCount += len(targets)
 	return handler.Remove(targets, params)
 }

--- a/pkg/rm/execute.go
+++ b/pkg/rm/execute.go
@@ -87,7 +87,7 @@ func (c *FieldOperationComponentEngine) SelectComponents(ctx context.Context, pa
 
 		if params.AllComponents {
 			log.Debugf("Selecting all components from CycloneDX BOM")
-			if raw.Metadata.Component != nil {
+			if raw.Metadata != nil && raw.Metadata.Component != nil {
 				result = append(result, raw.Metadata.Component)
 			}
 
@@ -103,7 +103,7 @@ func (c *FieldOperationComponentEngine) SelectComponents(ctx context.Context, pa
 			return nil, fmt.Errorf("component name and version are required unless --all-components is set")
 		}
 
-		if raw.Metadata.Component != nil && strings.EqualFold(raw.Metadata.Component.Name, name) && strings.EqualFold(raw.Metadata.Component.Version, version) {
+		if raw.Metadata != nil && raw.Metadata.Component != nil && strings.EqualFold(raw.Metadata.Component.Name, name) && strings.EqualFold(raw.Metadata.Component.Version, version) {
 			result = append(result, raw.Metadata.Component)
 		}
 		if raw.Components != nil {

--- a/pkg/rm/execute.go
+++ b/pkg/rm/execute.go
@@ -240,5 +240,7 @@ func (c *ComponentsOperationEngine) Execute(ctx context.Context, params *types.R
 		return fmt.Errorf("error removing dependencies: %w", err)
 	}
 
+	params.RemovedCount += len(selectedComponents) + len(selectedDeps)
+
 	return nil
 }

--- a/pkg/rm/field/cdx/filter.go
+++ b/pkg/rm/field/cdx/filter.go
@@ -121,9 +121,27 @@ func FilterLicenseFromMetadata(selected []interface{}, params *types.RmParams) (
 			log.Debugf("skipping license filter for non-license entry: %v", entry)
 			continue
 		}
-		if params.IsFieldAndValuePresent && license.License.Name == params.Value || license.License.ID == params.Value {
-			filtered = append(filtered, license)
+
+		match := false
+		if params.IsFieldAndValuePresent {
+			// Match expression
+			if license.Expression != "" && license.Expression == params.Value {
+				match = true
+			}
+			// Match license ID or Name
+			if license.License != nil {
+				if license.License.ID != "" && license.License.ID == params.Value {
+					match = true
+				}
+				if license.License.Name != "" && license.License.Name == params.Value {
+					match = true
+				}
+			}
 		} else if params.All || (!params.IsFieldAndKeyPresent && !params.IsFieldAndValuePresent) {
+			match = true
+		}
+
+		if match {
 			filtered = append(filtered, license)
 		}
 	}

--- a/pkg/rm/field/cdx/select.go
+++ b/pkg/rm/field/cdx/select.go
@@ -28,6 +28,10 @@ func SelectAuthorFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface{}
 	log := logger.FromContext(ctx)
 	log.Debugf("Selecting authors from metadata")
 
+	if bom.Metadata == nil {
+		return nil, nil
+	}
+
 	if bom.Metadata.Authors == nil || len(*bom.Metadata.Authors) == 0 {
 		return nil, nil
 	}
@@ -40,6 +44,10 @@ func SelectSupplierFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface
 	log := logger.FromContext(ctx)
 	log.Debugf("Selecting supplier from metadata")
 
+	if bom.Metadata == nil {
+		return nil, nil
+	}
+
 	if bom.Metadata.Supplier == nil {
 		return nil, nil
 	}
@@ -50,6 +58,10 @@ func SelectSupplierFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface
 func SelectTimestampFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface{}, error) {
 	log := logger.FromContext(ctx)
 	log.Debugf("Selecting timestamp from metadata")
+
+	if bom.Metadata == nil {
+		return nil, nil
+	}
 
 	if bom.Metadata.Timestamp == "" {
 		return nil, nil
@@ -62,6 +74,10 @@ func SelectTimestampFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interfac
 func SelectToolFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface{}, error) {
 	log := logger.FromContext(ctx)
 	log.Debugf("Selecting tool from metadata")
+
+	if bom.Metadata == nil {
+		return nil, nil
+	}
 
 	log.Debugf("Selecting tools from metadata")
 	if bom.Metadata.Tools == nil {
@@ -85,6 +101,10 @@ func SelectLicenseFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface{
 	log := logger.FromContext(ctx)
 	log.Debugf("Selecting licenses from metadata")
 
+	if bom.Metadata == nil {
+		return nil, nil
+	}
+
 	if bom.Metadata.Licenses == nil {
 		return nil, nil
 	}
@@ -101,6 +121,10 @@ func SelectLicenseFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface{
 func SelectLifecycleFromMetadata(ctx context.Context, bom *cydx.BOM) ([]interface{}, error) {
 	log := logger.FromContext(ctx)
 	log.Debugf("Selecting lifecycles from metadata")
+
+	if bom.Metadata == nil {
+		return nil, nil
+	}
 
 	if bom.Metadata.Lifecycles == nil {
 		return nil, nil

--- a/pkg/rm/types/params.go
+++ b/pkg/rm/types/params.go
@@ -59,4 +59,5 @@ type RmParams struct {
 	SelectedComponents []interface{}
 	AllComponents      bool
 	Ctx                *context.Context
+	RemovedCount       int
 }


### PR DESCRIPTION
closes #304 , https://github.com/interlynk-io/sbomasm/issues/305, https://github.com/interlynk-io/sbomasm/issues/306

This PR adds the following changes:
- Fix CDX nil metadata panics and license filter bugs
- Fix misleading "successfully removed..." output
- Fix license filter nil pointer and expression matching

Proofs:
- fixes metadata nil issue:
```bash
go run main.go rm --all --field license --scope component test.json 

successfully removed...
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "version": 0,
  "components": [
    {
      "type": "",
      "name": "test"
    }
  ]
}
no output file specified, writing to stdou
```

- Fix misleading "successfully removed..." output: replaced by "no matching entries found." when no matching found,
```bash
go run main.go rm --field license --scope document no-meta.json 
no matching entries found.
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.7",
  "version": 0,
  "components": [
    {
      "type": "library",
      "name": "test",
      "version": "1.0.0"
    }
  ]
}
no output file specified, writing to stdout
```

- Case A and Case B: Fix license filter nil pointer and expression matching
```bash
 go run main.go rm --field license --scope document -v "MIT" meta-expression.json
no matching entries found.
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.7",
  "version": 0,
  "metadata": {
    "licenses": [
      {
        "expression": "MIT OR Apache-2.0"
      }
    ]
  },
  "components": []
}
no output file specified, writing to stdout%                                                                                                                  

```

- case C: Expression never matched even with exact -v:
```bash
go run main.go rm --field license --scope document -v "MIT OR Apache-2.0" meta-mixed.json 

successfully removed...
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.7",
  "version": 0,
  "metadata": {
    "licenses": [
      {
        "license": {
          "id": "MIT"
        }
      }
    ]
  }
}
no output file specified, writing to stdout%   
```