### PR TITLE
fix merging strategy common bugs

### DIFF
--- a/pkg/assemble/cdx/merge.go
+++ b/pkg/assemble/cdx/merge.go
@@ -99,8 +99,8 @@ func (m *merge) combinedMerge() error {
 		log.Debugf("flat merge: final component list: %d", len(finalCompList))
 		m.out.Components = &finalCompList
 
-		priCompIds := lo.Map(priCompList, func(c cydx.Component, _ int) string {
-			return c.BOMRef
+		priCompIds := lo.FilterMap(priCompList, func(c cydx.Component, _ int) (string, bool) {
+			return c.BOMRef, c.BOMRef != ""
 		})
 		depList = append(depList, cydx.Dependency{
 			Ref:          m.out.Metadata.Component.BOMRef,
@@ -157,8 +157,8 @@ func (m *merge) combinedMerge() error {
 
 		m.out.Components = &priCompList
 
-		priCompIds := lo.Map(priCompList, func(c cydx.Component, _ int) string {
-			return c.BOMRef
+		priCompIds := lo.FilterMap(priCompList, func(c cydx.Component, _ int) (string, bool) {
+			return c.BOMRef, c.BOMRef != ""
 		})
 		depList = append(depList, cydx.Dependency{
 			Ref:          m.out.Metadata.Component.BOMRef,

--- a/pkg/assemble/cdx/merge.go
+++ b/pkg/assemble/cdx/merge.go
@@ -48,6 +48,7 @@ func (m *merge) loadBoms() {
 		if err != nil {
 			panic(err) // TODO: return error instead of panic
 		}
+		normalizeBomRefs(bom)
 		m.in = append(m.in, bom)
 	}
 }
@@ -139,14 +140,26 @@ func (m *merge) combinedMerge() error {
 				}
 			}
 
-			//Initialize the components list for the primary component
-			priCompList[newPc].Components = &[]cydx.Component{}
+			//Initialize the components list for the primary component (only once)
+			if priCompList[newPc].Components == nil {
+				priCompList[newPc].Components = &[]cydx.Component{}
+			}
+
+			// Track which components are already attached to avoid duplicates across BOMs
+			seenComp := make(map[string]struct{})
+			for _, comp := range *priCompList[newPc].Components {
+				seenComp[comp.BOMRef] = struct{}{}
+			}
 
 			for _, oldComp := range lo.FromPtr(b.Components) {
 				newCompId, _ := cs.ResolveDepID(oldComp.BOMRef)
+				if _, exists := seenComp[newCompId]; exists {
+					continue
+				}
 				for _, comp := range compList {
 					if comp.BOMRef == newCompId {
 						*priCompList[newPc].Components = append(*priCompList[newPc].Components, comp)
+						seenComp[newCompId] = struct{}{}
 						break
 					}
 				}
@@ -265,7 +278,7 @@ func (m *merge) setupPrimaryComp() *cydx.Component {
 		}
 	}
 
-	pc.BOMRef = newBomRef()
+	pc.BOMRef = generateComponentBomRef(&pc)
 	return &pc
 }
 

--- a/pkg/assemble/cdx/uniq_comp_service.go
+++ b/pkg/assemble/cdx/uniq_comp_service.go
@@ -64,7 +64,7 @@ func (s *uniqueComponentService) StoreAndCloneWithNewID(c *cydx.Component) (*cyd
 		panic(err)
 	}
 
-	newID := newBomRef()
+	newID := generateComponentBomRef(nc)
 	nc.BOMRef = newID
 
 	s.compMap[lookupKey] = nc

--- a/pkg/assemble/cdx/util.go
+++ b/pkg/assemble/cdx/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"time"
 
 	cydx "github.com/CycloneDX/cyclonedx-go"
@@ -306,7 +307,7 @@ func buildPrimaryComponentList(in []*cydx.BOM, cs *uniqueComponentService) []cyd
 			if !duplicate {
 				return *newComp, true
 			}
-			// Skip duplicate components - don't add empty entries
+			// Skip duplicate components: don't add empty entries
 			return cydx.Component{}, false
 		}
 		return cydx.Component{}, false
@@ -341,18 +342,22 @@ func buildDependencyList(in []*cydx.BOM, cs *uniqueComponentService) []cydx.Depe
 		}
 	}
 
-	// Convert map back to slice
-	return lo.Values(depMap)
+	// Convert map back to slice and sort for deterministic output
+	result := lo.Values(depMap)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Ref < result[j].Ref
+	})
+	return result
 }
 
 // mergeDependencyLists combines two dependency lists, removing duplicates
-func mergeDependencyLists(deps1, deps2 *[]string) []string {
+func mergeDependencyLists(exitingDeps, newDeps *[]string) []string {
 	depSet := make(map[string]struct{})
 
-	for _, d := range lo.FromPtr(deps1) {
+	for _, d := range lo.FromPtr(exitingDeps) {
 		depSet[d] = struct{}{}
 	}
-	for _, d := range lo.FromPtr(deps2) {
+	for _, d := range lo.FromPtr(newDeps) {
 		depSet[d] = struct{}{}
 	}
 
@@ -360,6 +365,7 @@ func mergeDependencyLists(deps1, deps2 *[]string) []string {
 	for d := range depSet {
 		result = append(result, d)
 	}
+	sort.Strings(result)
 	return result
 }
 

--- a/pkg/assemble/cdx/util.go
+++ b/pkg/assemble/cdx/util.go
@@ -269,20 +269,23 @@ func buildComponentList(in []*cydx.BOM, cs *uniqueComponentService) []cydx.Compo
 }
 
 func buildPrimaryComponentList(in []*cydx.BOM, cs *uniqueComponentService) []cydx.Component {
-	return lo.Map(in, func(bom *cydx.BOM, _ int) cydx.Component {
+	return lo.FilterMap(in, func(bom *cydx.BOM, _ int) (cydx.Component, bool) {
 		if bom.Metadata != nil && bom.Metadata.Component != nil {
 			newComp, duplicate := cs.StoreAndCloneWithNewID(bom.Metadata.Component)
 			if !duplicate {
-				return *newComp
+				return *newComp, true
 			}
+			// Skip duplicate components - don't add empty entries
+			return cydx.Component{}, false
 		}
-		return cydx.Component{}
+		return cydx.Component{}, false
 	})
 }
 
 func buildDependencyList(in []*cydx.BOM, cs *uniqueComponentService) []cydx.Dependency {
-	return lo.Flatten(lo.Map(in, func(bom *cydx.BOM, _ int) []cydx.Dependency {
-		newDeps := []cydx.Dependency{}
+	depMap := make(map[string]cydx.Dependency)
+
+	for _, bom := range in {
 		for _, dep := range lo.FromPtr(bom.Dependencies) {
 			nd := cydx.Dependency{}
 			ref, found := cs.ResolveDepID(dep.Ref)
@@ -297,10 +300,36 @@ func buildDependencyList(in []*cydx.BOM, cs *uniqueComponentService) []cydx.Depe
 			deps := cs.ResolveDepIDs(lo.FromPtr(dep.Dependencies))
 			nd.Ref = ref
 			nd.Dependencies = &deps
-			newDeps = append(newDeps, nd)
+
+			// If we already have this dependency, merge the dependsOn lists
+			if existingDep, exists := depMap[ref]; exists {
+				mergedDeps := mergeDependencyLists(existingDep.Dependencies, nd.Dependencies)
+				nd.Dependencies = &mergedDeps
+			}
+			depMap[ref] = nd
 		}
-		return newDeps
-	}))
+	}
+
+	// Convert map back to slice
+	return lo.Values(depMap)
+}
+
+// mergeDependencyLists combines two dependency lists, removing duplicates
+func mergeDependencyLists(deps1, deps2 *[]string) []string {
+	depSet := make(map[string]struct{})
+
+	for _, d := range lo.FromPtr(deps1) {
+		depSet[d] = struct{}{}
+	}
+	for _, d := range lo.FromPtr(deps2) {
+		depSet[d] = struct{}{}
+	}
+
+	result := make([]string, 0, len(depSet))
+	for d := range depSet {
+		result = append(result, d)
+	}
+	return result
 }
 
 // cloneVulnerability creates a deep copy of a vulnerability

--- a/pkg/assemble/cdx/util.go
+++ b/pkg/assemble/cdx/util.go
@@ -56,6 +56,37 @@ func newBomRef() string {
 	return fmt.Sprintf("lynk:%s", u)
 }
 
+// generateComponentBomRef creates a human-readable BOMRef based on component identity.
+// Prefers purl, falls back to name==version, then name, then a random lynk:uuid.
+func normalizeBomRefs(bom *cydx.BOM) {
+	if bom == nil {
+		return
+	}
+	if bom.Metadata != nil && bom.Metadata.Component != nil {
+		if bom.Metadata.Component.BOMRef == "" {
+			bom.Metadata.Component.BOMRef = generateComponentBomRef(bom.Metadata.Component)
+		}
+	}
+	for i := range lo.FromPtr(bom.Components) {
+		if bom.Components != nil && (*bom.Components)[i].BOMRef == "" {
+			(*bom.Components)[i].BOMRef = generateComponentBomRef(&(*bom.Components)[i])
+		}
+	}
+}
+
+func generateComponentBomRef(c *cydx.Component) string {
+	if c.PackageURL != "" {
+		return c.PackageURL
+	}
+	if c.Name != "" && c.Version != "" {
+		return fmt.Sprintf("%s@%s", c.Name, c.Version)
+	}
+	if c.Name != "" {
+		return c.Name
+	}
+	return newBomRef()
+}
+
 func cloneComp(c *cydx.Component) (*cydx.Component, error) {
 	var newComp cydx.Component
 


### PR DESCRIPTION
closes #308 

This PR adds the following changes:
- fixes empty components, duplicate deps, and empty depends-on for all merging strategy
- replaced bom-ref from `lynk-serial-number` to `bom-ref` > `name@version` > `name` > `lynk-serial-number`
- fix handling operation for similar primary component
  - handling empty bom-ref
  - accumulating components instead of replacing, as there is probability of losing unique components
  
 Proof:
 ```bash
 go run main.go assemble --hierMerge \
  -n cs.template -v 1.0.0 -t application \
  cs.template.linux.python_sbom.cdx.json \
  cs.template.win32.python_sbom.cdx.json \
  cs-template-components-base.linux.js_sbom.cdx.json \
  cs-template-components-base.win32.js_sbom.cdx.json \
  cs.foo.cdx.json \
  -o cs.template-new.cdx.json
```

Final SBOM `cs.template-new.cdx.json` contains:
- primary component
- 3 sub-components(`cs.foo`, `cs-template-components-base` , `cs.template`)
- and each sub-subcomponents contains their respective components
- dependencies: direct deps: (`cs.foo`, `cs-template-components-base` , `cs.template`), and respective dependencies of each components

```bash
cat cs.template-new.cdx.json
```

```json
{
  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
  "bomFormat": "CycloneDX",
  "specVersion": "1.7",
  "serialNumber": "urn:uuid:67eb5810-6f90-4c67-a987-77bc92ee0bd9",
  "version": 1,
  "metadata": {
    "timestamp": "2026-06-02T15:30:39Z",
    "tools": {
      "components": [
        {
          "type": "application",
          "supplier": {
            "name": "Interlynk",
            "url": [
              "https://interlynk.io"
            ],
            "contact": [
              {
                "email": "support@interlynk.io"
              }
            ]
          },
          "name": "sbomasm",
          "version": "devel",
          "description": "Assembler \u0026 Editor for your sboms",
          "licenses": [
            {
              "license": {
                "id": "Apache-2.0"
              }
            }
          ]
        },
        {
          "type": "application",
          "supplier": {
            "name": ""
          },
          "name": "webpack",
          "version": "5.103.0"
        },
        {
          "type": "application",
          "supplier": {
            "name": "@cyclonedx"
          },
          "name": "webpack-plugin",
          "version": "5.2.3"
        },
        {
          "type": "application",
          "supplier": {
            "name": "@cyclonedx"
          },
          "name": "cyclonedx-library",
          "version": "9.0.0"
        }
      ]
    },
    "component": {
      "bom-ref": "cs.template@1.0.0",
      "type": "application",
      "name": "cs.template",
      "version": "1.0.0"
    },
    "licenses": [
      {
        "license": {
          "id": "CC-BY-1.0"
        }
      }
    ]
  },
  "components": [
    {
      "bom-ref": "cs.template@2026.2.3.0.dev5",
      "type": "application",
      "name": "cs.template",
      "version": "2026.2.3.0.dev5",
      "components": [
        {
          "bom-ref": "pkg:pypi/idna@3.11",
          "type": "library",
          "name": "idna",
          "version": "3.11",
          "description": "Internationalized Domain Names in Applications (IDNA)",
          "purl": "pkg:pypi/idna@3.11"
        },
        {
          "bom-ref": "pkg:pypi/multidict@6.7.1",
          "type": "library",
          "name": "multidict",
          "version": "6.7.1",
          "description": "multidict implementation",
          "purl": "pkg:pypi/multidict@6.7.1"
        },
        {
          "bom-ref": "pkg:pypi/propcache@0.5.2",
          "type": "library",
          "name": "propcache",
          "version": "0.5.2",
          "description": "Accelerated property cache",
          "purl": "pkg:pypi/propcache@0.5.2"
        },
        {
          "bom-ref": "pkg:pypi/urllib3@2.7.0",
          "type": "library",
          "name": "urllib3",
          "version": "2.7.0",
          "description": "HTTP library with thread-safe connection pooling, file post, and more.",
          "purl": "pkg:pypi/urllib3@2.7.0"
        },
        {
          "bom-ref": "pkg:pypi/yarl@1.24.2",
          "type": "library",
          "name": "yarl",
          "version": "1.24.2",
          "description": "Yet another URL library",
          "purl": "pkg:pypi/yarl@1.24.2"
        }
      ]
    },
    {
      "bom-ref": "pkg:npm/cs-template-components-base@0.1.0",
      "type": "application",
      "author": "Contact Software GmbH",
      "name": "cs-template-components-base",
      "version": "0.1.0",
      "purl": "pkg:npm/cs-template-components-base@0.1.0",
      "components": [
        {
          "bom-ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
          "type": "library",
          "author": "Feross Aboukhadijeh",
          "name": "buffer",
          "version": "6.0.3",
          "description": "Node.js Buffer API, for the browser",
          "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git"
        },
        {
          "bom-ref": "pkg:npm/cs.template@1.0.0",
          "type": "library",
          "author": "CONTACT Software GmbH",
          "name": "cs.template",
          "version": "1.0.0",
          "description": "Package wide dependency declarations for cs.template",
          "purl": "pkg:npm/cs.template@1.0.0"
        },
        {
          "bom-ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
          "type": "library",
          "author": "T. Jameson Little",
          "name": "base64-js",
          "version": "1.5.1",
          "description": "Base64 encoding/decoding in pure JS",
          "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git"
        },
        {
          "bom-ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
          "type": "library",
          "author": "Feross Aboukhadijeh",
          "name": "ieee754",
          "version": "1.2.1",
          "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
          "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"
        },
        {
          "bom-ref": "pkg:npm/react-highlight-words@0.21.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbvaughn%2Freact-highlight-words.git",
          "type": "library",
          "author": "Brian Vaughn",
          "name": "react-highlight-words",
          "version": "0.21.0",
          "description": "React component to highlight words within a larger body of text",
          "purl": "pkg:npm/react-highlight-words@0.21.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbvaughn%2Freact-highlight-words.git"
        }
      ]
    },
    {
      "bom-ref": "cs.foo@0.1.0",
      "type": "application",
      "name": "cs.foo",
      "version": "0.1.0",
      "components": [
        {
          "bom-ref": "pkg:pypi/numpy@2.4.2",
          "type": "library",
          "name": "numpy",
          "version": "2.4.2",
          "description": "Fundamental package for array computing in Python",
          "purl": "pkg:pypi/numpy@2.4.2"
        }
      ]
    }
  ],
  "dependencies": [
    {
      "ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
      "dependsOn": [
        "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
        "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"
      ]
    },
    {
      "ref": "pkg:npm/cs-template-components-base@0.1.0",
      "dependsOn": [
        "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
        "pkg:npm/cs.template@1.0.0",
        "pkg:npm/react-highlight-words@0.21.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbvaughn%2Freact-highlight-words.git"
      ]
    },
    {
      "ref": "pkg:pypi/yarl@1.24.2",
      "dependsOn": [
        "pkg:pypi/idna@3.11",
        "pkg:pypi/multidict@6.7.1",
        "pkg:pypi/propcache@0.5.2"
      ]
    },
    {
      "ref": "cs.template@1.0.0",
      "dependsOn": [
        "cs.template@2026.2.3.0.dev5",
        "pkg:npm/cs-template-components-base@0.1.0",
        "cs.foo@0.1.0"
      ]
    }
  ]
}
```

