### PR TITLE
allow user to control datat license

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ sbomasm sign --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --output sbom-signed.
     - [Assembling SBOMs](#assembling-sboms)
       - [Simple Assembly](#simple-assembly)
       - [Container and Application Assembly](#container-and-application-assembly)
+      - [Document License](#document-license)
       - [Augment Merge (Enrich Existing SBOM)](#augment-merge-enrich-existing-sbom)
     - [Editing SBOMs](#editing-sboms)
       - [Add Missing Supplier Information](#add-missing-supplier-information)
@@ -182,6 +183,21 @@ sbomasm assemble \
   --type "container" \
   -o final-container.spdx.json \
   alpine-base.spdx.json app-deps.spdx.json
+```
+
+#### Document License
+
+Control the license of the assembled SBOM (default: CC0-1.0):
+
+```bash
+# Use default CC0-1.0 license
+sbomasm assemble -n "my-app" -v "1.0.0" -t "application" samples/test/assemble/lite-sbom1-cdx.json samples/test/assemble/lite-sbom2-cdx.json -o output-default-license.json
+
+# Specify a custom license
+sbomasm assemble -n "my-app" -v "1.0.0" -t "application" --doc-license "Apache-2.0" samples/test/assemble/lite-sbom1-cdx.json samples/test/assemble/lite-sbom2-cdx.json -o output-custom-license.json
+
+# Omit license entirely
+sbomasm assemble -n "my-app" -v "1.0.0" -t "application" --doc-license "none" samples/test/assemble/lite-sbom1-cdx.json samples/test/assemble/lite-sbom2-cdx.jsonn -o output-no-license.json
 ```
 
 #### Augment Merge (Enrich Existing SBOM)

--- a/cmd/assemble.go
+++ b/cmd/assemble.go
@@ -52,6 +52,10 @@ Augment Merge (enrich existing SBOM):
   $ sbomasm assemble --augmentMerge --primary base.json delta.json -o enriched.json
   $ sbomasm assemble --augmentMerge --primary base.json --merge-mode overwrite vendor-sbom.json
 
+Custom Document License (default: CC0-1.0):
+  $ sbomasm assemble -n "my-app" -v "1.0.0" -t "application" --doc-license "Apache-2.0" service1.json service2.json -o licensed.json
+  $ sbomasm assemble -n "my-app" -v "1.0.0" -t "application" --doc-license "none" service1.json service2.json -o no-license.json
+
 Config File:
   $ sbomasm generate > config.yaml
   $ sbomasm assemble -c config.yaml sbom1.json sbom2.json sbom3.json -o final.json
@@ -122,6 +126,9 @@ func init() {
 	assembleCmd.Flags().BoolP("augmentMerge", "", false, "augment merge - merge components into primary SBOM without creating new root")
 	assembleCmd.Flags().StringP("primary", "p", "", "primary SBOM file for augment merge (required for augment merge)")
 	assembleCmd.Flags().StringP("merge-mode", "", "if-missing-or-empty", "merge mode for augment merge: if-missing-or-empty, overwrite")
+
+	// Document license flag
+	assembleCmd.Flags().StringP("doc-license", "", "CC0-1.0", "document license for assembled SBOM metadata (default: CC0-1.0, use 'none' to omit)")
 
 	assembleCmd.MarkFlagsMutuallyExclusive("flatMerge", "hierMerge", "assemblyMerge", "augmentMerge")
 
@@ -208,6 +215,9 @@ func extractArgs(cmd *cobra.Command, args []string) (*assemble.Params, error) {
 
 	specVersion, _ := cmd.Flags().GetString("outputSpecVersion")
 	aParams.OutputSpecVersion = specVersion
+
+	docLicense, _ := cmd.Flags().GetString("doc-license")
+	aParams.DocLicense = docLicense
 
 	cdx, _ := cmd.Flags().GetBool("outputSpecCdx")
 

--- a/pkg/assemble/cdx/interface.go
+++ b/pkg/assemble/cdx/interface.go
@@ -125,6 +125,7 @@ type assemble struct {
 	AugmentMerge               bool
 	PrimaryFile                string
 	MergeMode                  string // if-missing-or-empty, overwrite
+	DocLicense                 string
 }
 
 type MergeSettings struct {

--- a/pkg/assemble/cdx/merge.go
+++ b/pkg/assemble/cdx/merge.go
@@ -209,11 +209,18 @@ func (m *merge) initOutBom() {
 		}
 	}
 
-	// Always add data sharing license.
-	m.out.Metadata.Licenses = &cydx.Licenses{
-		{
-			License: &cydx.License{ID: "CC-BY-1.0"},
-		},
+	// Add document license if specified (default: CC0-1.0, can be overridden via --doc-license)
+	// Use "none" or empty string to skip adding a license
+	docLicense := m.settings.Assemble.DocLicense
+	if docLicense == "" {
+		docLicense = "CC0-1.0" // Default license
+	}
+	if strings.ToLower(docLicense) != "none" && docLicense != "" {
+		m.out.Metadata.Licenses = &cydx.Licenses{
+			{
+				License: &cydx.License{ID: docLicense},
+			},
+		}
 	}
 
 	if len(m.settings.App.Authors) > 0 {

--- a/pkg/assemble/combiner.go
+++ b/pkg/assemble/combiner.go
@@ -95,6 +95,7 @@ func toCDXMergerSettings(c *config) *cdx.MergeSettings {
 	ms.Assemble.AugmentMerge = c.Assemble.AugmentMerge
 	ms.Assemble.PrimaryFile = c.Assemble.PrimaryFile
 	ms.Assemble.MergeMode = c.Assemble.MergeMode
+	ms.Assemble.DocLicense = c.Assemble.DocLicense
 	ms.Assemble.IncludeComponents = c.Assemble.IncludeComponents
 	ms.Assemble.IncludeDuplicateComponents = c.Assemble.includeDuplicateComponents
 	ms.Assemble.IncludeDependencyGraph = c.Assemble.IncludeDependencyGraph
@@ -157,6 +158,7 @@ func toSpdxMergerSettings(c *config) *spdx.MergeSettings {
 	ms.Assemble.AugmentMerge = c.Assemble.AugmentMerge
 	ms.Assemble.PrimaryFile = c.Assemble.PrimaryFile
 	ms.Assemble.MergeMode = c.Assemble.MergeMode
+	ms.Assemble.DocLicense = c.Assemble.DocLicense
 	ms.Assemble.IncludeComponents = c.Assemble.IncludeComponents
 	ms.Assemble.IncludeDuplicateComponents = c.Assemble.includeDuplicateComponents
 	ms.Assemble.IncludeDependencyGraph = c.Assemble.IncludeDependencyGraph

--- a/pkg/assemble/config.go
+++ b/pkg/assemble/config.go
@@ -100,6 +100,7 @@ type assemble struct {
 	AugmentMerge               bool   `yaml:"augment_merge"`
 	PrimaryFile                string `yaml:"primary_file"`
 	MergeMode                  string `yaml:"merge_mode"` // if-missing-or-empty, overwrite
+	DocLicense                 string `yaml:"doc_license"`
 }
 
 type config struct {
@@ -252,6 +253,10 @@ func (c *config) readAndMerge(p *Params) error {
 
 	if p.OutputSpecVersion != "" {
 		c.Output.SpecVersion = strings.Trim(p.OutputSpecVersion, " ")
+	}
+
+	if p.DocLicense != "" {
+		c.Assemble.DocLicense = strings.Trim(p.DocLicense, " ")
 	}
 
 	return nil

--- a/pkg/assemble/interface.go
+++ b/pkg/assemble/interface.go
@@ -47,6 +47,9 @@ type Params struct {
 	PrimaryFile string
 	MergeMode   string // if-missing-or-empty, overwrite
 
+	// Document license (metadata level, not component level)
+	DocLicense string
+
 	Xml  bool
 	Json bool
 

--- a/pkg/assemble/spdx/interface.go
+++ b/pkg/assemble/spdx/interface.go
@@ -109,6 +109,7 @@ type assemble struct {
 	AugmentMerge               bool
 	PrimaryFile                string
 	MergeMode                  string // if-missing-or-empty, overwrite
+	DocLicense                 string
 }
 
 type MergeSettings struct {


### PR DESCRIPTION
closes #313

This PR adds the following changes:
- it allows user to control sbom data license via `--doc-license` flag

Below Command:
- use `NOASSERTION` license
```bash
$ sbomasm assemble -n "my-app" -v "1.0.0" -t "application" --doc-license "NOASSERTION" samples/test/assemble/lite-sbom1-cdx.json samples/test/assemble/lite-sbom2-cdx.json -o doc-license-no-assertion.cdx.json
```

o/p:
```bash
 cat doc-license-no-assertion.cdx.json | jq '.metadata.licenses'
[
  {
    "license": {
      "id": "NOASSERTION"
    }
  }
]

```

- use `Apache-2.0` license
```bash
$ sbomasm assemble -n "my-app" -v "1.0.0" -t "application" --doc-license "Apache-2.0" samples/test/assemble/lite-sbom1-cdx.json samples/test/assemble/lite-sbom2-cdx.json -o doc-license-apache2.cdx.json
```

o/p:
```bash
❯ cat doc-license-apache2.cdx.json | jq '.metadata.licenses' 
[
  {
    "license": {
      "id": "Apache-2.0"
    }
  }
]
```

- omit license, use "none"
```bash
$ sbomasm assemble -n "my-app" -v "1.0.0" -t "application" --doc-license "none" samples/test/assemble/lite-sbom1-cdx.json samples/test/assemble/lite-sbom2-cdx.json -o doc-license-none.cdx.json
```

o/p:
```bash
cat doc-license-none.cdx.json | jq '.metadata.licenses' 
null

```

- use default license
```bash
$ sbomasm  assemble -n "my-app" -v "1.0.0" -t "application" samples/test/assemble/lite-sbom1-cdx.json samples/test/assemble/lite-sbom2-cdx.json -o doc-license-default.cdx.json 
```

o/p:
```bash
❯ cat doc-license-default.cdx.json | jq '.metadata.licenses' 
[
  {
    "license": {
      "id": "CC0-1.0"
    }
  }
]

```
