### PR TITLE
update docker meta version to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Debug extracted tags
+        run: |
+          echo "Tags: ${{ steps.meta.outputs.tags }}"
 
       - name: Build and push
         id: push

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,5 +100,3 @@ changelog:
 release:
   prerelease: auto
   draft: true
-  make_latest: true 
-


### PR DESCRIPTION
This PR adds the following changes:

Problem caused by GitHub Immutable Releases:

  **Problem:**
  - With Immutable Releases enabled, once a release is published, assets cannot be added/modified/deleted.
  - GoReleaser was trying to upload binaries to an already-published release, therefore failed with 422 error: see here: https://github.com/interlynk-io/sbomasm/actions/runs/28219951128/job/83598789304
  - Docker `metadata-action@v5` wasn't extracting version tags from release events: see here: https://github.com/interlynk-io/sbomasm/actions/runs/28219951123
  
  **Changes:**
  1. **Update `docker/metadata-action` from v5 to v6**
  2. **Add `draft: true` to `.goreleaser.yaml`**
     - Creates draft release first , then uploads assets, then you manually publish
     - Ensures assets exist before release becomes immutable
 
 **New Release Workflow:**
  ```bash
  # Push tag locally (no more manual release creation on GitHub UI)
 $ git tag v2.0.8
 $ git push upstream v2.0.8
```
- CI automatically:
  - Creates draft release
  - Builds and uploads all binaries
  - Creates Docker images

Then manually click "Publish release" on GitHub

