### PR TITLE
[bug] handle both deprecated as well as new way of metadata.tools

### DIFF
--- a/pkg/edit/cdx.go
+++ b/pkg/edit/cdx.go
@@ -277,7 +277,23 @@ func cdxUniqTools(a *cydx.ToolsChoice, b *cydx.ToolsChoice) *cydx.ToolsChoice {
 func cdxConstructTools(b *cydx.BOM, c *configParams) *cydx.ToolsChoice {
 	choice := cydx.ToolsChoice{}
 
-	if b.SpecVersion > cydx.SpecVersion1_4 {
+	// Determine which format to use based on BOM's existing tools, not just SpecVersion
+	// If BOM has old format (Tools.Tools), create new tools in old format
+	// If BOM has new format (Tools.Components) or no tools, use SpecVersion to decide
+	useComponents := false
+	if b.Metadata != nil && b.Metadata.Tools != nil {
+		if b.Metadata.Tools.Tools != nil {
+			useComponents = false
+		} else if b.Metadata.Tools.Components != nil {
+			useComponents = true
+		} else {
+			useComponents = b.SpecVersion > cydx.SpecVersion1_4
+		}
+	} else {
+		useComponents = b.SpecVersion > cydx.SpecVersion1_4
+	}
+
+	if useComponents {
 		choice.Components = new([]cydx.Component)
 	} else {
 		choice.Tools = new([]cydx.Tool)
@@ -289,7 +305,7 @@ func cdxConstructTools(b *cydx.BOM, c *configParams) *cydx.ToolsChoice {
 		key := fmt.Sprintf("%s-%s", strings.ToLower(tool.name), strings.ToLower(tool.value))
 
 		if _, ok := uniqTools[key]; !ok {
-			if b.SpecVersion > cydx.SpecVersion1_4 {
+			if useComponents {
 				*choice.Components = append(*choice.Components, cydx.Component{
 					Type:    cydx.ComponentTypeApplication,
 					Name:    tool.name,

--- a/pkg/edit/cdx_edit.go
+++ b/pkg/edit/cdx_edit.go
@@ -382,24 +382,40 @@ func (d *cdxEditDoc) initializeMetadataTools() {
 		d.bom.Metadata = &cydx.Metadata{}
 	}
 
-	if d.bom.SpecVersion > cydx.SpecVersion1_4 {
-		if d.bom.Metadata.Tools == nil {
+	if d.bom.Metadata.Tools == nil {
+		// No tools exist yet, initialize based on spec version
+		if d.bom.SpecVersion > cydx.SpecVersion1_4 {
 			d.bom.Metadata.Tools = &cydx.ToolsChoice{
 				Components: new([]cydx.Component),
 			}
-		}
-		if d.bom.Metadata.Tools.Components == nil {
-			d.bom.Metadata.Tools.Components = new([]cydx.Component)
-		}
-	} else {
-		if d.bom.Metadata.Tools == nil {
+		} else {
 			d.bom.Metadata.Tools = &cydx.ToolsChoice{
 				Tools: new([]cydx.Tool),
 			}
 		}
-		if d.bom.Metadata.Tools.Tools == nil {
-			d.bom.Metadata.Tools.Tools = new([]cydx.Tool)
+		return
+	}
+
+	// Tools already exists - preserve existing format, don't mix both!
+	// CycloneDX doesn't allow both Tools.Tools and Tools.Components to be set
+	if d.bom.Metadata.Tools.Tools != nil {
+		// Old format (array of tools) already present - keep it
+		// remove Components if present
+		if d.bom.Metadata.Tools.Components != nil {
+			d.bom.Metadata.Tools.Components = nil
 		}
+		return
+	}
+
+	if d.bom.Metadata.Tools.Components != nil {
+		return
+	}
+
+	// Tools exists but both are nil - initialize based on spec version
+	if d.bom.SpecVersion > cydx.SpecVersion1_4 {
+		d.bom.Metadata.Tools.Components = new([]cydx.Component)
+	} else {
+		d.bom.Metadata.Tools.Tools = new([]cydx.Tool)
 	}
 }
 
@@ -429,12 +445,12 @@ func (d *cdxEditDoc) detectExplicitComponent(components *[]cydx.Component, sboma
 
 // handle missing case for tools.tools and tools.components case
 func (d *cdxEditDoc) addMissingToolsOrComponents(newTools *cydx.ToolsChoice, sbomasmTool cydx.Tool, sbomasmComponent cydx.Component) {
-	if d.bom.SpecVersion > cydx.SpecVersion1_4 {
+	if d.bom.Metadata.Tools.Components != nil {
 		d.bom.Metadata.Tools.Components = cdxUniqueComponents(*d.bom.Metadata.Tools.Components, *newTools.Components)
 		if !componentExists(d.bom.Metadata.Tools.Components, sbomasmComponent) {
 			*d.bom.Metadata.Tools.Components = append(*d.bom.Metadata.Tools.Components, sbomasmComponent)
 		}
-	} else {
+	} else if d.bom.Metadata.Tools.Tools != nil {
 		d.bom.Metadata.Tools.Tools = cdxUniqueTools(*d.bom.Metadata.Tools.Tools, *newTools.Tools)
 		if !toolExists(d.bom.Metadata.Tools.Tools, sbomasmTool) {
 			*d.bom.Metadata.Tools.Tools = append(*d.bom.Metadata.Tools.Tools, sbomasmTool)
@@ -444,12 +460,12 @@ func (d *cdxEditDoc) addMissingToolsOrComponents(newTools *cydx.ToolsChoice, sbo
 
 // handle append case for tools.tools and tools.components case
 func (d *cdxEditDoc) appendToolsOrComponents(newTools *cydx.ToolsChoice, sbomasmTool cydx.Tool, sbomasmComponent cydx.Component) {
-	if d.bom.SpecVersion > cydx.SpecVersion1_4 {
+	if d.bom.Metadata.Tools.Components != nil {
 		d.bom.Metadata.Tools.Components = cdxUniqueComponents(*d.bom.Metadata.Tools.Components, *newTools.Components)
 		if !componentExists(d.bom.Metadata.Tools.Components, sbomasmComponent) {
 			*d.bom.Metadata.Tools.Components = append(*d.bom.Metadata.Tools.Components, sbomasmComponent)
 		}
-	} else {
+	} else if d.bom.Metadata.Tools.Tools != nil {
 		d.bom.Metadata.Tools.Tools = cdxUniqueTools(*d.bom.Metadata.Tools.Tools, *newTools.Tools)
 		if !toolExists(d.bom.Metadata.Tools.Tools, sbomasmTool) {
 			*d.bom.Metadata.Tools.Tools = append(*d.bom.Metadata.Tools.Tools, sbomasmTool)
@@ -459,12 +475,12 @@ func (d *cdxEditDoc) appendToolsOrComponents(newTools *cydx.ToolsChoice, sbomasm
 
 // handle default case for tools.tools and tools.components case
 func (d *cdxEditDoc) mergeToolsOrComponents(newTools *cydx.ToolsChoice, sbomasmTool cydx.Tool, sbomasmComponent cydx.Component) {
-	if d.bom.SpecVersion > cydx.SpecVersion1_4 {
+	if d.bom.Metadata.Tools.Components != nil {
 		d.bom.Metadata.Tools.Components = cdxUniqueComponents(*d.bom.Metadata.Tools.Components, *newTools.Components)
 		if !componentExists(d.bom.Metadata.Tools.Components, sbomasmComponent) {
 			*d.bom.Metadata.Tools.Components = append(*d.bom.Metadata.Tools.Components, sbomasmComponent)
 		}
-	} else {
+	} else if d.bom.Metadata.Tools.Tools != nil {
 		d.bom.Metadata.Tools.Tools = cdxUniqueTools(*d.bom.Metadata.Tools.Tools, *newTools.Tools)
 		if !toolExists(d.bom.Metadata.Tools.Tools, sbomasmTool) {
 			*d.bom.Metadata.Tools.Tools = append(*d.bom.Metadata.Tools.Tools, sbomasmTool)


### PR DESCRIPTION
closes #323 

What was the issue:
- Even if deprecated `metadata.tools.tools` was present, it adds new `metadata.tools.components`. As a result, cyclonedx go library throws an valid error, as both can't be placed, only oneOf would be added.

This PR adds the following changes:
- it handle both deprecated tools and new way of adding tools.
- If deprecated tooling is already present, then continue appending `sbomasm` tool into it, no need to create new component tool.
- If component tool is present, then continue appending `sbomasm` tool into it.
- If neither is present, then refer to the SBOM spec version,
  - if spec version > 1.4, create components tools(`metadata.tools.components`)
  - else create deprecated tools(`metadata.tools.tools`)
  
  
  o/p:
<details>
<summary> see detailed o/p </summary>

```bash
   go run main.go edit --missing --subject document --supplier "example (example.com)" sbomasm-issue-323-original.cdx.json
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "serialNumber": "urn:uuid:629356bb-5b0f-4382-8ba2-a64374236d86",
  "version": 1,
  "metadata": {
    "timestamp": "2026-07-08T11:59:27Z",
    "tools": [
      {
        "vendor": "OWASP",
        "name": "Dependency-Track",
        "version": "4.14.2"
      },
      {
        "name": "sbomasm",
        "version": "devel"
      }
    ],
    "component": {
      "bom-ref": "1b3d8c84-796e-4353-9a00-0d2a25c03e07",
      "type": "application",
      "name": "APP",
      "version": "1.0.0",
      "purl": "pkg:maven/com.example/app@1.0.0",
      "externalReferences": [
        {
          "url": "https://example.com/build",
          "type": "build-system"
        }
      ]
    },
    "supplier": {
      "bom-ref": "sbomasm:4512d5ee-8a33-4582-843f-2f95ec0a4b33",
      "name": "example",
      "url": [
        "example.com"
      ]
    }
  }
}
```
</details>
  
  