### PR TITLE
Update SecureSBOM SDK and detached signature handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ sbomasm generate > config.yml
 
 # Sign an SBOM using ShiftLeftCyber's SecureSBOM API (using a sample key)
 sbomasm sign --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --output sbom-signed.json sbom.json
+
+# Sign and verify an SPDX SBOM using a detached signature response file
+sbomasm sign --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --output sbom.spdx.signed.json sbom.spdx.json
+sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature sbom.spdx.signed.json sbom.spdx.json
 ```
 
 ## Table of Contents
@@ -402,7 +406,7 @@ API Key. To obtain an API key use the following: [ContactUs](https://shiftleftcy
 
 1. **API Key:** Obtain an API Key from ShiftLeftCyber
 2. **Key Management:** Generate or use existing signing keys through the SecureSBOM Service
-3. **Envorionment Setup:** Set your API key as an environment variable for convenience 
+3. **Environment Setup:** Set your API key as an environment variable for convenience
 
 ```bash
 export SECURE_SBOM_API_KEY="your-api-key-here"
@@ -412,16 +416,26 @@ export SECURE_SBOM_API_KEY="your-api-key-here"
 # Generate a Signing Key for signing and online verification
 sbomasm securesbomkey generate
 
-# Use the generated key to Sign a CycloneDX SBOM according to CycloneDX 1.6 Specification
-# The below examples uses a fake/sample key for educational purposes only
+# Use the generated key to sign a CycloneDX SBOM according to the CycloneDX signature format.
+# The examples below use a fake/sample key for educational purposes only.
 sbomasm sign --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --output sbom.cdx.signed.json sbom.json
 
-# Verify the Signed SBOM using the API
+# Verify the CycloneDX signed response using the API
 sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e sbom.cdx.signed.json
 
-# Sign and Verify SPDX SBOMs with SecureSBOM
+# Sign and verify a CycloneDX SBOM with a detached signature response file
+sbomasm sign --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --detached --output sbom.cdx.detached.json sbom.cdx.json
+sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature sbom.cdx.detached.json sbom.cdx.json
+
+# Sign and verify an SPDX SBOM with a detached signature response file
 sbomasm sign --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --output sbom.spdx.signed.json sbom.spdx.json
-sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature "SIGNATURE_HASH" sbom.spdx.signed.json
+sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature sbom.spdx.signed.json sbom.spdx.json
+
+# SPDX verification also accepts a raw base64 signature
+sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature "MEUCIQD..." sbom.spdx.json
+
+# Or an inline JSON signing response payload
+sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature '{"algorithm":"ES256","detached":true,"sbom_type":"spdx","signature_b64":"MEUCIQD..."}' sbom.spdx.json
 ```
 
 ## Industry Use Cases

--- a/cmd/securesbomkey.go
+++ b/cmd/securesbomkey.go
@@ -139,11 +139,11 @@ func init() {
 	keyGenerateCmd.Flags().StringVar(&keyOutputFormat, "output", "table", "Output format: table, json")
 
 	keyGenerateCmd.Flags().BoolVar(
-        &filesystemKey,
-        "filesystemkey",
-        false,
-        "Generate filesystem-backed key (NOT FOR PRODUCTION USE)",
-    )
+		&filesystemKey,
+		"filesystemkey",
+		false,
+		"Generate filesystem-backed key (NOT FOR PRODUCTION USE)",
+	)
 
 	// Output file flag for public command
 	keyPublicCmd.Flags().StringVar(&keyOutput, "output", "", "Output file path (default: stdout)")
@@ -189,15 +189,6 @@ func runKeyListCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
-	// Perform health check
-	if !keyQuiet {
-		fmt.Fprintf(os.Stderr, "Connecting to Secure SBOM API...\n")
-	}
-
-	if err := client.HealthCheck(ctx); err != nil {
-		return fmt.Errorf("API health check failed: %w", err)
-	}
-
 	// List keys
 	if !keyQuiet {
 		fmt.Fprintf(os.Stderr, "Retrieving keys...\n")
@@ -232,15 +223,6 @@ func runKeyGenerateCommand(cmd *cobra.Command, args []string) error {
 	client, err := createKeyClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	// Perform health check
-	if !keyQuiet {
-		fmt.Fprintf(os.Stderr, "Connecting to Secure SBOM API...\n")
-	}
-
-	if err := client.HealthCheck(ctx); err != nil {
-		return fmt.Errorf("API health check failed: %w", err)
 	}
 
 	var backend string
@@ -281,15 +263,6 @@ func runKeyPublicCommand(cmd *cobra.Command, args []string) error {
 	client, err := createKeyClient()
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	// Perform health check
-	if !keyQuiet {
-		fmt.Fprintf(os.Stderr, "Connecting to Secure SBOM API...\n")
-	}
-
-	if err := client.HealthCheck(ctx); err != nil {
-		return fmt.Errorf("API health check failed: %w", err)
 	}
 
 	// Get public key

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -156,15 +156,6 @@ func runSignCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load SBOM: %w", err)
 	}
 
-	// Perform health check
-	if !signQuiet {
-		fmt.Fprintf(os.Stderr, "Connecting to Secure SBOM API...\n")
-	}
-
-	if err := client.HealthCheck(ctx); err != nil {
-		return fmt.Errorf("API health check failed: %w", err)
-	}
-
 	// Sign the SBOM
 	if !signQuiet {
 		fmt.Fprintf(os.Stderr, "Signing SBOM with key %s...\n", signKeyID)
@@ -246,7 +237,7 @@ func loadSBOMForSigning(inputFile string) (*securesbom.SBOM, error) {
 }
 
 // outputSignedSBOM writes the signed SBOM to the specified output location with pretty formatting
-func outputSignedSBOM(result *securesbom.SignResultAPIResponse) error {
+func outputSignedSBOM(result *securesbom.SignResultAPIResponseV2) error {
 	// Pretty-print the JSON with indentation
 	prettyJSON, err := json.MarshalIndent(*result, "", "  ")
 	if err != nil {

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/shiftleftcyber/securesbom-sdk-golang/v2/pkg/securesbom"
@@ -45,7 +46,7 @@ Examples:
   sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --api-key $API_KEY signed-cyclonedx-sbom.json
 
   # Verify a SPDX Detached Signature
-  sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature "SIGNATURE HASH" --api-key $API_KEY signed-cyclonedx-sbom.json
+  sbomasm verify --key-id a7b3c9e1-2f4d-4a8b-9c6e-1d5f7a9b2c4e --signature signed-spdx-response.json --api-key $API_KEY spdx-sbom.json
 
   # Verify with environment variable for API key
   export SECURE_SBOM_API_KEY=your-api-key
@@ -71,7 +72,7 @@ var (
 	verifyTimeout      time.Duration
 	verifyRetryCount   int
 	verifyQuiet        bool
-	verifySignature	   string
+	verifySignature    string
 )
 
 // VerificationOutput represents the CLI output structure
@@ -90,7 +91,7 @@ func init() {
 
 	// Verification Flag
 	verifyCmd.Flags().StringVar(&verifyKeyID, "key-id", "", "Key ID used to sign the SBOM")
-	verifyCmd.Flags().StringVar(&verifySignature, "signature", "", "Base64 signature to veirfy when using an SPDX SBOM")
+	verifyCmd.Flags().StringVar(&verifySignature, "signature", "", "Detached signature value, JSON signing response, or path to a signature response file")
 
 	// Authentication flags
 	verifyCmd.Flags().StringVar(&verifyAPIKey, "api-key", "", "API key for authentication (or set SECURE_SBOM_API_KEY)")
@@ -189,34 +190,32 @@ func runVerifyCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load signed SBOM: %w", err)
 	}
 
-	// Perform health check
-	if !verifyQuiet {
-		fmt.Fprintf(os.Stderr, "Connecting to Secure SBOM API...\n")
-	}
-
-	if err := client.HealthCheck(ctx); err != nil {
-		return fmt.Errorf("API health check failed: %w", err)
-	}
-
 	var result *securesbom.VerifyResultCMDResponse
-	if verifySignature != "" {
-		// SPDX SBOM - use separate signature
+	verifyReq := securesbom.VerifyCMDRequest{
+		KeyID: verifyKeyID,
+		SBOM:  signedSBOM.Data(),
+	}
+	signatureInput, err := loadSignatureInput(verifySignature)
+	if err != nil {
+		return fmt.Errorf("failed to load signature input: %w", err)
+	}
+
+	if signatureInput != "" {
+		verifyReq.SignatureB64 = signatureInput
+
 		if !verifyQuiet {
-			fmt.Fprintf(os.Stderr, "Verifying SPDX SBOM with provided signature...\n")
-		}
-		result, err = client.VerifySPDXSBOM(ctx, verifyKeyID, verifySignature, signedSBOM.Data())
-		if err != nil {
-			return fmt.Errorf("failed to verify SPDX SBOM: %w", err)
+			fmt.Fprintf(os.Stderr, "Verifying SBOM with provided detached signature...\n")
 		}
 	} else {
 		// CycloneDX SBOM - signature embedded in SBOM
 		if !verifyQuiet {
 			fmt.Fprintf(os.Stderr, "Verifying CycloneDX SBOM with embedded signature...\n")
 		}
-		result, err = client.VerifySBOM(ctx, verifyKeyID, signedSBOM.Data())
-		if err != nil {
-			return fmt.Errorf("failed to verify CycloneDX SBOM: %w", err)
-		}
+	}
+
+	result, err = client.VerifySBOM(ctx, verifyReq)
+	if err != nil {
+		return fmt.Errorf("failed to verify SBOM: %w", err)
 	}
 
 	// Output the verification result
@@ -269,6 +268,41 @@ func loadSBOMForVerification(inputFile string) (*securesbom.SBOM, error) {
 	}
 
 	return securesbom.LoadSBOMFromFile(inputFile)
+}
+
+func loadSignatureInput(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	if looksLikeInlineJSON(value) {
+		return value, nil
+	}
+
+	fileInfo, err := os.Stat(value)
+	if err == nil {
+		if fileInfo.IsDir() {
+			return "", fmt.Errorf("signature path is a directory: %s", value)
+		}
+
+		signatureBytes, err := os.ReadFile(value)
+		if err != nil {
+			return "", fmt.Errorf("failed to read signature file %s: %w", value, err)
+		}
+		return strings.TrimSpace(string(signatureBytes)), nil
+	}
+
+	if os.IsNotExist(err) {
+		return value, nil
+	}
+
+	return value, nil
+}
+
+func looksLikeInlineJSON(value string) bool {
+	return (strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}")) ||
+		(strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]")) ||
+		(strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\""))
 }
 
 func outputVerificationResult(result *securesbom.VerifyResultCMDResponse) error {

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Interlynk.io and Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSignatureInput(t *testing.T) {
+	signaturePayload := `{"algorithm":"ES256","detached":true,"sbom_type":"spdx","signature_b64":"MEQCID8yI8pYVaduL"}`
+	signatureFile := filepath.Join(t.TempDir(), "signature.json")
+	if err := os.WriteFile(signatureFile, []byte(signaturePayload+"\n"), 0600); err != nil {
+		t.Fatalf("failed to write signature fixture: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty signature",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "raw signature",
+			input:    "MEQCID8yI8pYVaduL",
+			expected: "MEQCID8yI8pYVaduL",
+		},
+		{
+			name:     "json signature payload",
+			input:    signaturePayload,
+			expected: signaturePayload,
+		},
+		{
+			name:     "json string signature payload",
+			input:    `"MEQCID8yI8pYVaduL"`,
+			expected: `"MEQCID8yI8pYVaduL"`,
+		},
+		{
+			name:     "signature payload file",
+			input:    signatureFile,
+			expected: signaturePayload,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := loadSignatureInput(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestLoadSignatureInputRejectsDirectory(t *testing.T) {
+	_, err := loadSignatureInput(t.TempDir())
+	if err == nil {
+		t.Fatal("expected directory input to fail")
+	}
+}

--- a/docs/securesbom.md
+++ b/docs/securesbom.md
@@ -1,8 +1,8 @@
 # SecureSBOM API
 
 `sbomasm` provides enterprise-grade cryptographic signing and verification for SBOMs through integration with
-ShiftLeftCyber's SecureSBOM API. The implementation supports the standard **CycloneDX Signature Format** and 
-**SPDX** detached signatures
+ShiftLeftCyber's SecureSBOM API. The implementation supports **CycloneDX** embedded and detached signatures and
+**SPDX** detached signatures.
 
 ## Why Sign SBOMs?
 
@@ -64,16 +64,33 @@ sbomasm securesbomkey public <key-id>
 sbomasm sign --key-id <your-key-id> <input-sbom>
 ```
 
-### Verifying an SBOM (CycloneDX)
+By default, CycloneDX signing returns a signed SBOM response with the signed document in `signed_sbom`. SPDX signing
+returns a detached signature response because SPDX signatures are not embedded into the SBOM.
+
+Use `--detached` to request a detached signature response:
+
+```bash
+sbomasm sign --key-id <your-key-id> --detached --output signed-response.json <input-sbom>
+```
+
+### Verifying a CycloneDX SBOM With Embedded Signature
 
 ```bash
 sbomasm verify --key-id <key-id> <signed-sbom>
 ```
 
-### Verifying an SBOM (SPDX)
+### Verifying a CycloneDX SBOM With Detached Signature
 
 ```bash
-sbomasm verify --key-id <key-id> --signature <base64 signature> <signed-sbom>
+sbomasm verify --key-id <key-id> --signature signed-cyclonedx-detached-response.json <original-sbom>
+```
+
+CycloneDX detached verification requires the detached signing response JSON, not only the raw signature value.
+
+### Verifying an SPDX SBOM With Detached Signature
+
+```bash
+sbomasm verify --key-id <key-id> --signature <base64-signature-json-payload-or-file> <original-sbom>
 ```
 
 ## Command Options
@@ -83,14 +100,18 @@ sbomasm verify --key-id <key-id> --signature <base64 signature> <signed-sbom>
 #### Required Options
 - `--key-id <string>`: Key ID to use for signing the SBOM
 
+#### Signing Options
+- `--detached`: Return a detached signature response instead of the default signing response
+
 #### Authentication Options
 - `--api-key <string>`: API key for authentication (or set `SECURE_SBOM_API_KEY`)
+- `--base-url <url>`: Base URL for SecureSBOM API (or set `SECURE_SBOM_BASE_URL`)
 
 #### Output Options
-- `-o, --output <path>`: Output file path for signed SBOM
+- `--output <path>`: Output file path for signed SBOM
   - Default: stdout
   - Use `-` for explicit stdout output
-- `-q, --quiet`: Suppress progress messages and status output
+- `--quiet`: Suppress progress messages and status output
 
 #### Network Options
 - `--timeout <duration>`: Request timeout (default: 30s)
@@ -102,41 +123,59 @@ sbomasm verify --key-id <key-id> --signature <base64 signature> <signed-sbom>
 - `--key-id <string>`: Public key ID used to verify the signature
 
 #### Required Options (SPDX Verification)
-- `--signature <string>`: base64 signature of the SBOM
+- `--signature <string>`: Detached signature value, detached signing response JSON, or path to a signature response file
+
+For SPDX, `--signature` may be a raw base64 signature, the full JSON signing response containing `signature_b64`, or
+a path to a file containing either form. For CycloneDX detached signatures, pass the full detached signing response JSON
+or a path to the detached signing response file.
 
 #### Authentication Options
-- `--api-key <base64 string>`: API key for authentication (or set `SECURE_SBOM_API_KEY`)
+- `--api-key <string>`: API key for authentication (or set `SECURE_SBOM_API_KEY`)
+- `--base-url <url>`: Base URL for SecureSBOM API (or set `SECURE_SBOM_BASE_URL`)
 
 #### Output Options
-- `-q, --quiet`: Suppress output except for errors (exit code indicates success/failure)
+- `--output <format>`: Output format, either `text` or `json` (default: `text`)
+- `--quiet`: Suppress progress output (exit code indicates success/failure)
 
 #### Network Options
 - `--timeout <duration>`: Request timeout (default: 30s)
 - `--retry <number>`: Number of retry attempts for failed requests (default: 3)
 
-### Keys Command
+### Securesbomkey Command
 
 #### Subcommands
 - `generate`: Generate a new cryptographic key pair
 - `list`: List all available keys in your account
 - `public <key-id>`: Retrieve the public key for sharing
 
+#### Authentication Options
+- `--api-key <string>`: API key for authentication (or set `SECURE_SBOM_API_KEY`)
+- `--base-url <url>`: Base URL for SecureSBOM API (or set `SECURE_SBOM_BASE_URL`)
+
+#### Output Options
+- `securesbomkey list --output table|json`: Output list results as a table or JSON
+- `securesbomkey generate --output table|json`: Output generated key details as a table or JSON
+- `securesbomkey public <key-id> --output <path>`: Write the public key PEM to a file
+- `--quiet`: Suppress progress output
+
 ## How It Works
 
 ### Signing Process
 
 1. **Authentication**: Connects to SecureSBOM API using your API key
-2. **Key Validation**: Verifies the specified key ID exists is linked to your account
+2. **Key Validation**: Verifies the specified key ID exists and is linked to your account
 3. **SBOM Processing**: Parses and validates the input SBOM format
 4. **Signature Generation**: Creates a cryptographic signature using your private key
 5. **Format Integration**: Embeds the signature according to format standards:
-   - **CycloneDX**: Uses the standard 1.6 signature format within the SBOM
-   - **SPDX**: Adds detached signature metadata
-6. **Output**: Returns the signed SBOM with embedded cryptographic proof or deatached signature for SPDX
+   - **CycloneDX**: Supports embedded signatures and detached signature responses
+   - **SPDX**: Uses detached signature responses
+6. **Output**: Returns a JSON signing response. For embedded CycloneDX signatures, the signed SBOM is in `signed_sbom`.
+   For detached signatures, the response contains the detached signature material.
 
 ### Verification Process
 
-1. **Signature Extraction**: Extracts the embedded signature from the signed SBOM or uses the value passed in
+1. **Signature Extraction**: Extracts an embedded CycloneDX signature from the signed SBOM or uses the detached
+   signature value passed with `--signature`
 2. **Key Retrieval**: Fetches the corresponding public key using the key ID
 3. **Hash Verification**: Validates the SBOM content against the signature
 4. **Integrity Check**: Confirms the SBOM has not been modified since signing
@@ -146,7 +185,7 @@ sbomasm verify --key-id <key-id> --signature <base64 signature> <signed-sbom>
 
 The SecureSBOM API manages your cryptographic keys securely:
 - **Key Generation**: Creates an ECDSA key pair
-- **Secure Storage**: Private keys are securely stored in a Hardware Security Modules (HSM)
+- **Secure Storage**: Private keys are securely stored by the SecureSBOM service
 - **Access Control**: Keys are tied to your API account and access permissions
 - **Public Key Sharing**: Public keys can be shared for verification purposes
 
@@ -158,11 +197,17 @@ The SecureSBOM API manages your cryptographic keys securely:
 # Sign an SBOM
 sbomasm sign --key-id prod-key-2024 --output signed-sbom.json sbom.json
 
-# Verify the signed SBOM
+# Verify a CycloneDX signed response with embedded signature
 sbomasm verify --key-id prod-key-2024 signed-sbom.json
 
-# Verify the signed SPDX SBOM
-sbomasm verify --key-id prod-key-2024 --signature "MEUCIQDmi8q+VTLgRcByA....." signed-sbom.json
+# Sign a CycloneDX SBOM with a detached signature response
+sbomasm sign --key-id prod-key-2024 --detached --output signed-cdx-detached.json sbom.cdx.json
+
+# Verify a CycloneDX SBOM with a detached signature response file
+sbomasm verify --key-id prod-key-2024 --signature signed-cdx-detached.json sbom.cdx.json
+
+# Verify an SPDX SBOM with a detached signature response file
+sbomasm verify --key-id prod-key-2024 --signature signed-spdx.json sbom.spdx.json
 ```
 
 ### Environment Variables Setup
@@ -175,8 +220,7 @@ export SECURE_SBOM_API_KEY="your-api-key-here"
 Output example:
 ```
 Loading signed SBOM...
-Connecting to Secure SBOM API...
-Verifying SBOM signature with key 045728s6-h18q-649z-67fdb-27c2afcab510...
+Verifying CycloneDX SBOM with embedded signature...
 ✓ SBOM signature is VALID
 Message: signature is valid
 Key ID: 045728s6-h18q-649z-67fdb-27c2afcab510
@@ -315,7 +359,7 @@ done
 VENDOR_KEY="vendor-public-key"
 INTERNAL_KEY="internal-key-2024"
 
-# Verify vendor-provided SBOM
+# Verify vendor-provided CycloneDX SBOM with embedded signature
 echo "Verifying vendor SBOM..."
 if sbomasm verify --key-id "$VENDOR_KEY" --quiet vendor-sbom.json; then
     echo "✓ Vendor SBOM signature valid"
@@ -346,7 +390,7 @@ Error: API key is required. Use --api-key flag or set SECURE_SBOM_API_KEY enviro
 ```
 Error: key ID 'invalid-key' not found
 ```
-**Solution**: Verify the key exists with `sbomasm keys list`
+**Solution**: Verify the key exists with `sbomasm securesbomkey list`
 
 ### Network Timeouts
 ```
@@ -363,14 +407,14 @@ sbomasm sign --timeout 60s --retry 5 --key-id my-key sbom.json
 
 | Format | Version | Signing | Verification | Notes |
 |--------|---------|---------|--------------|-------|
-| CycloneDX | 1.6+ | ✅ | ✅ | Uses standard signature format |
-| CycloneDX | 1.4-1.5 | ✅ | ✅ | Compatible with 1.6 signature format |
-| SPDX | 2.3+ | ✅ | ✅ | Detached signature support |
+| CycloneDX | 1.6+ | Yes | Yes | Embedded and detached signature support |
+| CycloneDX | 1.4-1.5 | Yes | Yes | Compatible with CycloneDX signature format |
+| SPDX | 2.3+ | Yes | Yes | Detached signature support only |
 
 ## Future Enhancements
 
 * **Signature Metadata**: Additional signature attributes and custom claims
-* **Spport for Air Gapped Verification**: Veirfy a signed sbom offline with only the public key
+* **Support for Air-Gapped Verification**: Verify a signed SBOM offline with only the public key
 * **CycloneDX Multi-Signature Support**: Multiple signatures on single SBOM
 * **Signature Chain Support**: Hierarchical signature chains for supply chain trust
 * **Certificate Authority (CA)** integration for key management

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/package-url/packageurl-go v0.1.6
 	github.com/pingcap/log v1.1.0
 	github.com/samber/lo v1.53.0
-	github.com/shiftleftcyber/securesbom-sdk-golang/v2 v2.3.0
+	github.com/shiftleftcyber/securesbom-sdk-golang/v2 v2.7.1
 	github.com/spdx/tools-golang v0.5.7
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
 github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
-github.com/shiftleftcyber/securesbom-sdk-golang/v2 v2.3.0 h1:HpTIaljQaJeSNaz5T+qZNraozUOl9mf/BR+07KROcKs=
-github.com/shiftleftcyber/securesbom-sdk-golang/v2 v2.3.0/go.mod h1:aZ1vQXBg0uj0whHNaFU0UYdFyMnWs7V8TmwB5fUC6Ro=
+github.com/shiftleftcyber/securesbom-sdk-golang/v2 v2.7.1 h1:HgT0yLA0AwB2vUVnWg9P4vmNa2nmdxSmc9RDT4+/3og=
+github.com/shiftleftcyber/securesbom-sdk-golang/v2 v2.7.1/go.mod h1:b6PVxCUYem4FdCmRTbRTalE1VEWuh8RRTFwRz6VsBcg=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spdx/gordf v0.0.0-20250128162952-000978ccd6fb h1:7G2Czq97VORM5xNRrD8tSQdhoXPRs8s+Otlc7st9TS0=


### PR DESCRIPTION
## Summary

  - Update SecureSBOM SDK dependency to v2.7.1
  - Support `--signature` as a raw signature, inline JSON payload, or path to a signature response file
  - Improve SecureSBOM verification UX based on feedback from Vivek
  - Use the newer SDK behavior for better error handling and less verbose API interaction
  - Avoid the extra healthcheck call before signing and verification requests
  - Update SecureSBOM docs and README examples for CycloneDX and SPDX detached verification
  - Add tests for signature input loading

  ## Validation

  - `go test ./cmd`
  - `go test ./...`
  - `go vet ./...`
  - `make build`