### PR TITLE
fix primary comp dangling refs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Force LF line endings for test data files to ensure cross-platform consistency
+*.json text eol=lf
+*.txt text eol=lf
+*.spdx text eol=lf
+*.cdx text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+# Copyright 2026 Interlynk.io
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+  workflow_call:
+
+env:
+  GO_VERSION: "1.22"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Install dependencies
+        run: make deps
+
+      - name: Run tests
+        run: make test
+
+      - name: Run integration tests
+        run: make integration-test
+
+  test-matrix:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Install dependencies
+        run: make deps
+
+      - name: Run tests
+        run: make test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Build binary
+        run: make build
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbomasm-binary
+          path: build/sbomasm
+          if-no-files-found: error
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ test: generate ## Run all tests
 	@echo "Running tests..."
 	@go test -cover -race ./...
 
+.PHONY: integration-test
+integration-test: generate ## Run integration tests
+	@echo "Running integration tests..."
+	@go test -v ./pkg/assemble/integration_test/...
+
 ##@ Building
 
 .PHONY: build
@@ -169,7 +174,7 @@ ci: deps generate vet ## Run CI pipeline locally with test summary
 	UNIT_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "Integration tests:"; \
-	go test -run "Test_ScoreForStaticSBOMFiles_Summary|Test_NTIAProfile|Test_NTIA2025Profile|Test_InterlynkProfile" ./pkg/scorer/v2/... 2>&1 | grep -E "(PASS|FAIL|ok|NTIA.*Profile:|Interlynk.*Profile:)" ; \
+	go test -v ./pkg/assemble/integration_test/... 2>&1 | grep -E "(RUN|PASS|FAIL|ok)" ; \
 	INTEGRATION_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \

--- a/pkg/assemble/cdx/merge.go
+++ b/pkg/assemble/cdx/merge.go
@@ -97,6 +97,19 @@ func (m *merge) combinedMerge() error {
 		primaryBom := m.in[0]
 		m.initOutBomFromPrimary(primaryBom)
 		m.out.Metadata.Component = m.extractPrimaryComponent(primaryBom)
+
+		// Normalize the primary component's BOMRef to match the normalized dependency refs.
+		// The primary component may have been stored in the component service with a
+		// normalized ID (e.g., "name@version"), but the extracted component still has
+		// the original BOMRef (e.g., "name==version"). We need them to match.
+		if m.out.Metadata.Component != nil {
+			originalBomRef := m.out.Metadata.Component.BOMRef
+			if normalizedRef, found := cs.ResolveDepID(originalBomRef); found {
+				m.out.Metadata.Component.BOMRef = normalizedRef
+				log.Debugf("flat merge with primary: normalized primary component BOMRef from %s to %s",
+					originalBomRef, normalizedRef)
+			}
+		}
 	} else {
 		m.initOutBom()
 		m.out.Metadata.Component = m.setupPrimaryComp()
@@ -456,6 +469,14 @@ func (m *merge) assemblyMergeWithPrimary(cs *uniqueComponentService, compList []
 	m.out.Metadata.Component = m.extractPrimaryComponent(primaryBom)
 	if m.out.Metadata.Component == nil {
 		return fmt.Errorf("primary SBOM has no primary component")
+	}
+
+	// Normalize the primary component's BOMRef to match dependency refs
+	originalBomRef := m.out.Metadata.Component.BOMRef
+	if normalizedRef, found := cs.ResolveDepID(originalBomRef); found {
+		m.out.Metadata.Component.BOMRef = normalizedRef
+		log.Debugf("assembly merge with primary: normalized primary component BOMRef from %s to %s",
+			originalBomRef, normalizedRef)
 	}
 
 	log.Debugf("assembly merge with primary: using primary component %s", m.out.Metadata.Component.BOMRef)

--- a/pkg/assemble/cdx/merge_assembly_primary_test.go
+++ b/pkg/assemble/cdx/merge_assembly_primary_test.go
@@ -474,6 +474,193 @@ func TestAssemblyMergeWithPrimary_ErrorNoPrimaryComponent(t *testing.T) {
 	}
 }
 
+// Test for GitHub Issue #330: Primary component bom-ref normalization
+// When primary component has a bom-ref without purl (e.g., "myapp==1.0.0"),
+// it should be normalized to match the dependency refs (e.g., "myapp@1.0.0")
+
+// Primary SBOM with non-normalized bom-ref (no purl, uses "==" format)
+var assemblyPrimaryNonNormalizedSBOM = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:44444444-4444-4444-4444-444444444444",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "myapp",
+      "version": "1.0.0",
+      "bom-ref": "myapp==1.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "lodash",
+      "version": "4.17.21",
+      "bom-ref": "pkg:npm/lodash@4.17.21",
+      "purl": "pkg:npm/lodash@4.17.21"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "myapp==1.0.0",
+      "dependsOn": ["pkg:npm/lodash@4.17.21"]
+    }
+  ]
+}
+`)
+
+// Secondary SBOM for issue #330 test
+var assemblySecondaryNonNormalizedSBOM = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:55555555-5555-5555-5555-555555555555",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "secondary",
+      "version": "2.0.0",
+      "bom-ref": "secondary==2.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "react",
+      "version": "17.0.0",
+      "bom-ref": "pkg:npm/react@17.0.0",
+      "purl": "pkg:npm/react@17.0.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "secondary==2.0.0",
+      "dependsOn": ["pkg:npm/react@17.0.0"]
+    }
+  ]
+}
+`)
+
+// Test: Issue #330 - Assembly merge with primary normalizes bom-ref
+func TestAssemblyMergeWithPrimary_BomRefNormalization(t *testing.T) {
+	ctx := setupTestContext()
+
+	primary, err := parseCDXBytes(assemblyPrimaryNonNormalizedSBOM)
+	if err != nil {
+		t.Fatalf("failed to parse primary SBOM: %v", err)
+	}
+	secondary, err := parseCDXBytes(assemblySecondaryNonNormalizedSBOM)
+	if err != nil {
+		t.Fatalf("failed to parse secondary SBOM: %v", err)
+	}
+
+	ms := &MergeSettings{
+		Ctx:   &ctx,
+		Input: input{Files: []string{"primary.cdx.json", "secondary.cdx.json"}},
+		Assemble: assemble{
+			IsAssemblyMergeWithPrimary: true,
+			PrimaryFile:                "primary.cdx.json",
+		},
+	}
+
+	m := newMerge(ms)
+	m.in = []*cydx.BOM{primary, secondary}
+	cs := newUniqueComponentService(ctx)
+
+	// Build component lists - this also stores the primary component in the service
+	// and creates the idMap entry needed for bom-ref normalization
+	priCompList := buildPrimaryComponentList(m.in, cs)
+	compList := buildComponentList(m.in, cs)
+	depList := buildDependencyList(m.in, cs)
+
+	// Verify primary component was stored with normalized bom-ref
+	// This is required for the fix in assemblyMergeWithPrimary to work
+	if len(priCompList) == 0 {
+		t.Fatal("expected primary component in priCompList")
+	}
+
+	err = m.assemblyMergeWithPrimary(cs, compList, depList)
+	if err != nil {
+		t.Fatalf("assemblyMergeWithPrimary failed: %v", err)
+	}
+
+	t.Run("primary component bom-ref is normalized", func(t *testing.T) {
+		if m.out.Metadata.Component == nil {
+			t.Fatal("expected metadata.component to be set")
+		}
+
+		primaryBomRef := m.out.Metadata.Component.BOMRef
+		if primaryBomRef == "" {
+			t.Fatal("primary component should have a bom-ref")
+		}
+
+		// The bom-ref should be normalized ("myapp@1.0.0" not "myapp==1.0.0")
+		if primaryBomRef == "myapp==1.0.0" {
+			t.Error("primary component bom-ref should be normalized (myapp@1.0.0), not original format (myapp==1.0.0)")
+		}
+		if primaryBomRef != "myapp@1.0.0" {
+			t.Errorf("expected normalized bom-ref 'myapp@1.0.0', got '%s'", primaryBomRef)
+		}
+	})
+
+	t.Run("primary component bom-ref matches dependency refs", func(t *testing.T) {
+		if m.out.Metadata.Component == nil {
+			t.Fatal("expected metadata.component to be set")
+		}
+
+		primaryBomRef := m.out.Metadata.Component.BOMRef
+
+		// Check that at least one dependency refs the primary
+		foundPrimaryRef := false
+		for _, dep := range *m.out.Dependencies {
+			if dep.Ref == primaryBomRef {
+				foundPrimaryRef = true
+				break
+			}
+		}
+
+		if !foundPrimaryRef {
+			t.Errorf("primary component bom-ref (%s) should match at least one dependency ref", primaryBomRef)
+			t.Logf("dependencies: %+v", *m.out.Dependencies)
+		}
+	})
+
+	t.Run("no dangling references in dependencies", func(t *testing.T) {
+		// Collect all component bom-refs
+		componentRefs := make(map[string]bool)
+		if m.out.Metadata.Component != nil {
+			componentRefs[m.out.Metadata.Component.BOMRef] = true
+		}
+		if m.out.Metadata.Component.Components != nil {
+			for _, comp := range *m.out.Metadata.Component.Components {
+				componentRefs[comp.BOMRef] = true
+			}
+		}
+		for _, comp := range *m.out.Components {
+			componentRefs[comp.BOMRef] = true
+		}
+
+		// Check that all dependency refs point to existing components
+		for _, dep := range *m.out.Dependencies {
+			if !componentRefs[dep.Ref] {
+				t.Errorf("dependency ref '%s' does not point to any component", dep.Ref)
+			}
+			if dep.Dependencies != nil {
+				for _, depDep := range *dep.Dependencies {
+					if !componentRefs[depDep] {
+						t.Errorf("nested dependency ref '%s' does not point to any component", depDep)
+					}
+				}
+			}
+		}
+	})
+}
+
 // Helper functions
 
 var testLoggerOnce sync.Once

--- a/pkg/assemble/integration_test/assemble_integration_test.go
+++ b/pkg/assemble/integration_test/assemble_integration_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Interlynk.io
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	cydx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/interlynk-io/sbomasm/v2/pkg/assemble"
+	"github.com/interlynk-io/sbomasm/v2/pkg/logger"
+)
+
+var testLoggerOnce sync.Once
+
+// TestMain initializes the logger before running tests
+func TestMain(m *testing.M) {
+	testLoggerOnce.Do(func() {
+		logger.InitProdLogger()
+	})
+	m.Run()
+}
+
+// getTestDataDir returns the path to the testdata directory
+func getTestDataDir() string {
+	_, currentFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(currentFile), "testdata")
+}
+
+// Test_FlatMergeWithPrimary_BomRefNormalization tests
+// Verifies that flat merge with --primary normalizes the primary component's bom-ref
+// to match the dependency refs, preventing dangling references.
+func Test_FlatMergeWithPrimary_BomRefNormalization(t *testing.T) {
+	// Create temp output file
+	outputFile := filepath.Join(t.TempDir(), "issue330-flat-merge-output.cdx.json")
+
+	// Get test data paths
+	testDataDir := filepath.Join(getTestDataDir(), "issue330")
+	primaryFile := filepath.Join(testDataDir, "primary.cdx.json")
+	secondaryFile := filepath.Join(testDataDir, "secondary.cdx.json")
+
+	// Setup context and params
+	ctx := logger.WithLogger(context.Background())
+	params := assemble.NewParams()
+	params.Ctx = &ctx
+	params.Input = []string{secondaryFile}
+	params.Output = outputFile
+	params.FlatMerge = true
+	params.PrimaryFile = primaryFile
+	params.Json = true
+	params.OutputSpec = "cyclonedx"
+
+	// Populate config and run assemble
+	config, err := assemble.PopulateConfig(params)
+	if err != nil {
+		t.Fatalf("PopulateConfig failed: %v", err)
+	}
+
+	err = assemble.Assemble(config)
+	if err != nil {
+		t.Fatalf("Assemble failed: %v", err)
+	}
+
+	// Read and parse output
+	f, err := os.Open(outputFile)
+	if err != nil {
+		t.Fatalf("Failed to open output file: %v", err)
+	}
+	defer f.Close()
+
+	bom := new(cydx.BOM)
+	decoder := cydx.NewBOMDecoder(f, cydx.BOMFileFormatJSON)
+	if err := decoder.Decode(bom); err != nil {
+		t.Fatalf("Failed to parse output JSON: %v", err)
+	}
+
+	// Verify primary component bom-ref is normalized (myapp@1.0.0, not myapp==1.0.0)
+	if bom.Metadata == nil || bom.Metadata.Component == nil {
+		t.Fatal("metadata.component should be set")
+	}
+	primaryBomRef := bom.Metadata.Component.BOMRef
+	if primaryBomRef == "" {
+		t.Fatal("metadata.component.bom-ref should not be empty")
+	}
+
+	// The bom-ref should be normalized
+	if contains := containsSubstring(primaryBomRef, "=="); contains {
+		t.Errorf("Primary component bom-ref should be normalized (use @ not ==), got: %s", primaryBomRef)
+	}
+
+	expectedBomRef := "myapp@1.0.0"
+	if primaryBomRef != expectedBomRef {
+		t.Errorf("Primary component bom-ref should be normalized to %s, got %s", expectedBomRef, primaryBomRef)
+	}
+
+	// Verify that at least one dependency refs the primary component
+	foundPrimaryRef := false
+	if bom.Dependencies != nil {
+		for _, dep := range *bom.Dependencies {
+			if dep.Ref == primaryBomRef {
+				foundPrimaryRef = true
+				break
+			}
+		}
+	}
+	if !foundPrimaryRef {
+		t.Errorf("No dependency refs found for primary component bom-ref %q", primaryBomRef)
+	}
+
+	t.Logf("✓ Primary component bom-ref normalized: %s", primaryBomRef)
+	t.Logf("✓ Dependency refs match primary bom-ref")
+}
+
+// Test_AssemblyMergeWithPrimary_BomRefNormalization test
+// Verifies that assembly merge with --primary normalizes the primary component's bom-ref
+func Test_AssemblyMergeWithPrimary_BomRefNormalization(t *testing.T) {
+	// Create temp output file
+	outputFile := filepath.Join(t.TempDir(), "issue330-assembly-merge-output.cdx.json")
+
+	// Get test data paths
+	testDataDir := filepath.Join(getTestDataDir(), "issue330")
+	primaryFile := filepath.Join(testDataDir, "primary.cdx.json")
+	secondaryFile := filepath.Join(testDataDir, "secondary.cdx.json")
+
+	// Setup context and params
+	ctx := logger.WithLogger(context.Background())
+	params := assemble.NewParams()
+	params.Ctx = &ctx
+	params.Input = []string{secondaryFile}
+	params.Output = outputFile
+	params.AssemblyMerge = true
+	params.PrimaryFile = primaryFile
+	params.Json = true
+	params.OutputSpec = "cyclonedx"
+
+	// Populate config and run assemble
+	config, err := assemble.PopulateConfig(params)
+	if err != nil {
+		t.Fatalf("PopulateConfig failed: %v", err)
+	}
+
+	err = assemble.Assemble(config)
+	if err != nil {
+		t.Fatalf("Assemble failed: %v", err)
+	}
+
+	// Read and parse output
+	f, err := os.Open(outputFile)
+	if err != nil {
+		t.Fatalf("Failed to open output file: %v", err)
+	}
+	defer f.Close()
+
+	bom := new(cydx.BOM)
+	decoder := cydx.NewBOMDecoder(f, cydx.BOMFileFormatJSON)
+	if err := decoder.Decode(bom); err != nil {
+		t.Fatalf("Failed to parse output JSON: %v", err)
+	}
+
+	// Verify primary component bom-ref is normalized
+	if bom.Metadata == nil || bom.Metadata.Component == nil {
+		t.Fatal("metadata.component should be set")
+	}
+	primaryBomRef := bom.Metadata.Component.BOMRef
+	if primaryBomRef == "" {
+		t.Fatal("metadata.component.bom-ref should not be empty")
+	}
+
+	// The bom-ref should be normalized
+	if contains := containsSubstring(primaryBomRef, "=="); contains {
+		t.Errorf("Primary component bom-ref should be normalized (use @ not ==), got: %s", primaryBomRef)
+	}
+
+	expectedBomRef := "myapp@1.0.0"
+	if primaryBomRef != expectedBomRef {
+		t.Errorf("Primary component bom-ref should be normalized to %s, got %s", expectedBomRef, primaryBomRef)
+	}
+
+	// Verify that at least one dependency refs the primary component
+	foundPrimaryRef := false
+	if bom.Dependencies != nil {
+		for _, dep := range *bom.Dependencies {
+			if dep.Ref == primaryBomRef {
+				foundPrimaryRef = true
+				break
+			}
+		}
+	}
+	if !foundPrimaryRef {
+		t.Errorf("No dependency refs found for primary component bom-ref %q", primaryBomRef)
+	}
+
+	t.Logf("✓ Primary component bom-ref normalized: %s", primaryBomRef)
+	t.Logf("✓ Dependency refs match primary bom-ref")
+}
+
+// containsSubstring is a helper to check if a string contains a substring
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/assemble/integration_test/testdata/issue330/primary.cdx.json
+++ b/pkg/assemble/integration_test/testdata/issue330/primary.cdx.json
@@ -1,0 +1,30 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:44444444-4444-4444-4444-444444444444",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "myapp",
+      "version": "1.0.0",
+      "bom-ref": "myapp==1.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "lodash",
+      "version": "4.17.21",
+      "bom-ref": "pkg:npm/lodash@4.17.21",
+      "purl": "pkg:npm/lodash@4.17.21"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "myapp==1.0.0",
+      "dependsOn": ["pkg:npm/lodash@4.17.21"]
+    }
+  ]
+}

--- a/pkg/assemble/integration_test/testdata/issue330/secondary.cdx.json
+++ b/pkg/assemble/integration_test/testdata/issue330/secondary.cdx.json
@@ -1,0 +1,30 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:55555555-5555-5555-5555-555555555555",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-01-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "secondary",
+      "version": "2.0.0",
+      "bom-ref": "secondary==2.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "react",
+      "version": "17.0.0",
+      "bom-ref": "pkg:npm/react@17.0.0",
+      "purl": "pkg:npm/react@17.0.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "secondary==2.0.0",
+      "dependsOn": ["pkg:npm/react@17.0.0"]
+    }
+  ]
+}


### PR DESCRIPTION
closes #330 

THis PR adds the following changes:
- fixes dangling reference for primary component.
- added functional tests and integration tests for this case(in future will extend this accordinly)
- also added ci/cd workflow to run test coverage + all tests and specifically integration test verbosely.
- also add `.gitattributes` for end-of-line, `eol` as `lf` to avoid different `eol` for windows/ubuntu. This is important because there is a test case for `edit` command which compare line by line, and if `eol` differs then test fails. Therefore it is necessary to set `eol` same of all os.

Examples:
```bash
$  go run main.go assemble --flatMerge --primary primary.cdx.json \ 
  --outputSpecVersion 1.6 extra.cdx.json -o out-new.cdx.json 
```

o/p:
```json
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "serialNumber": "urn:uuid:b0755551-5205-4654-a0d0-5a16978fb829",
  "version": 1,
  "metadata": {
    "timestamp": "2026-07-21T06:59:37Z",
    "tools": {
      "components": [
        {
          "type": "application",
          "supplier": {
            "name": "Interlynk",
            "url": [
              "https://interlynk.io"
            ],
            "contact": [
              {
                "email": "support@interlynk.io"
              }
            ]
          },
          "name": "sbomasm",
          "version": "devel",
          "description": "Assembler \u0026 Editor for your sboms",
          "licenses": [
            {
              "license": {
                "id": "Apache-2.0"
              }
            }
          ]
        }
      ]
    },
    "component": {
      "bom-ref": "myapp@1.0.0",
      "type": "application",
      "name": "myapp",
      "version": "1.0.0"
    },
    "licenses": [
      {
        "license": {
          "id": "CC-BY-1.0"
        }
      }
    ]
  },
  "components": [
    {
      "bom-ref": "pkg:npm/extra@2.0.0",
      "type": "library",
      "name": "extra",
      "version": "2.0.0",
      "purl": "pkg:npm/extra@2.0.0"
    },
    {
      "bom-ref": "pkg:pypi/leftpad@1.3.0",
      "type": "library",
      "name": "leftpad",
      "version": "1.3.0",
      "purl": "pkg:pypi/leftpad@1.3.0"
    }
  ],
  "dependencies": [
    {
      "ref": "myapp@1.0.0",
      "dependsOn": [
        "pkg:pypi/leftpad@1.3.0",
        "pkg:npm/extra@2.0.0"
      ]
    }
  ]
}
```