### PR TITLE
fix(enrich): accept 201 Created from the ClearlyDefined harvest API

### DIFF
--- a/pkg/enrich/clearlydef/client.go
+++ b/pkg/enrich/clearlydef/client.go
@@ -220,7 +220,10 @@ func queueHarvest(ctx context.Context, retryClient *retryablehttp.Client, coordi
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	// The ClearlyDefined harvest endpoint answers 200 OK when the item was
+	// already queued/known and 201 Created when a new harvest job was
+	// created for it. Both are successful outcomes (see issue #270).
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("unexpected status code for harvest: %d", resp.StatusCode)
 	}
 

--- a/pkg/enrich/clearlydef/client_201_test.go
+++ b/pkg/enrich/clearlydef/client_201_test.go
@@ -1,0 +1,74 @@
+// Test for issue #270: ClearlyDefined Harvest API now returns 201 Created
+// on success, but queueHarvest only accepted exactly 200, so a successful
+// harvest request was reported as an error.
+package clearlydef
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/guacsec/sw-id-core/coordinates"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+type fakeRoundTripper struct {
+	status int
+}
+
+func (f *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: f.status,
+		Status:     http.StatusText(f.status),
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+		Request:    r,
+	}, nil
+}
+
+func newFakeStatusClient(status int) *retryablehttp.Client {
+	c := retryablehttp.NewClient()
+	c.RetryMax = 0
+	c.Logger = nil
+	c.HTTPClient.Transport = &fakeRoundTripper{status: status}
+	return c
+}
+
+func testCoordinate() coordinates.Coordinate {
+	return coordinates.Coordinate{
+		CoordinateType: "npm",
+		Provider:       "npmjs",
+		Namespace:      "-",
+		Name:           "example",
+		Revision:       "1.0.0",
+	}
+}
+
+// Issue #270: the real API now answers 201 Created for a queued harvest.
+// queueHarvest must treat this as success, not as an error.
+func TestQueueHarvest_Returns201_IsTreatedAsSuccess(t *testing.T) {
+	client := newFakeStatusClient(http.StatusCreated) // 201
+	err := queueHarvest(context.Background(), client, testCoordinate())
+	if err != nil {
+		t.Fatalf("expected 201 Created to be treated as success, got error: %v", err)
+	}
+}
+
+func TestQueueHarvest_Returns200_IsTreatedAsSuccess(t *testing.T) {
+	client := newFakeStatusClient(http.StatusOK) // 200, pre-existing behavior
+	err := queueHarvest(context.Background(), client, testCoordinate())
+	if err != nil {
+		t.Fatalf("expected 200 OK to be treated as success, got error: %v", err)
+	}
+}
+
+// Make sure the fix does not silently swallow genuine failures.
+func TestQueueHarvest_Returns500_IsStillAnError(t *testing.T) {
+	client := newFakeStatusClient(http.StatusInternalServerError) // 500
+	err := queueHarvest(context.Background(), client, testCoordinate())
+	if err == nil {
+		t.Fatalf("expected HTTP 500 to still be reported as an error")
+	}
+}


### PR DESCRIPTION
Fixes #270.

The ClearlyDefined harvest endpoint answers `200 OK` when the coordinate is already known/queued and `201 Created` when a new harvest job is created for it. `queueHarvest` accepted exactly 200, so the most common successful outcome for a fresh component — a newly queued harvest — was reported as `unexpected status code for harvest: 201` and the enrichment was treated as failed.

The check now accepts both success codes; anything else is still an error.

Tests (`pkg/enrich/clearlydef/client_201_test.go`, using a stubbed `RoundTripper`, no network):

* `201 Created` → success — fails on `main` with the exact error from the issue, passes here;
* `200 OK` → success (pre-existing behavior, pinned);
* `500` → still an error, so the fix cannot be satisfied by dropping the status check altogether.

`go test ./pkg/enrich/clearlydef/`, `go vet`, `gofmt` clean.
