### PR TITLE
fix(cmd): show usage when edit is run without its input file

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -55,7 +55,13 @@ Advanced Example:
 	$ sbomasm edit --subject primary-component --hash "MD5 (hash1)" --hash "SHA256 (hash2)" in-sbom-5.json
 	`,
 	SilenceUsage: true,
-	Args:         cobra.ExactArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+			cmd.Println(cmd.UsageString())
+			return err
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		debug, _ := cmd.Flags().GetBool("debug")
 		if debug {

--- a/cmd/edit_usage_test.go
+++ b/cmd/edit_usage_test.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Interlynk.io and Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Reproduces interlynk-io/sbomasm#185: subcommands run without their
+// required positional argument print only the bare cobra error
+// ("accepts 1 arg(s), received 0") and no usage/flags block, because
+// SilenceUsage is set to true on the subcommand. This test invokes the
+// real rootCmd (as main.main() does) exactly the way the issue reporter
+// did: `sbomasm edit` with no input file.
+func TestEditMissingArgShowsUsage(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"edit"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when required positional arg is missing")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Usage:") {
+		t.Fatalf("expected usage/help text to be shown when required arg is missing, got only:\n%s", out)
+	}
+	if !strings.Contains(out, "--subject") {
+		t.Fatalf("expected flag list (e.g. --subject) to be shown when required arg is missing, got only:\n%s", out)
+	}
+}


### PR DESCRIPTION
Fixes #185.

The subcommands set `SilenceUsage: true`, so running e.g. `sbomasm edit` without its required input file printed only cobra's bare `accepts 1 arg(s), received 0` — no usage, no flag list, which is exactly the complaint in the issue. `SilenceUsage` is there to keep *runtime* errors from dumping help text, so simply removing it would regress that.

Instead, the `Args` validator is wrapped: when the argument-count check fails, the command prints its usage block first and then returns the same error (exit code and error text unchanged).

Test (`cmd/edit_usage_test.go`) drives the real `rootCmd` with `[]string{"edit"}`, the same invocation as the issue: on `main` it fails (no `Usage:` in the output), here it passes, asserting both the usage header and the flag list are shown.

`go test ./cmd/`, `go vet`, `gofmt` clean.
